### PR TITLE
Mini mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ SOLVER FLAG[-s] Set maze solving algorithm.
     [dark[algorithm]-[game]] - A mystery...
 
 WALL FLAG[-w] Set the wall style for the maze.
-    [sharp] - Half size walls and paths.
+    [mini] - Half size walls and paths.
     [sharp] - The default straight lines.
     [round] - Rounded corners.
     [doubles] - Sharp double lines.

--- a/README.md
+++ b/README.md
@@ -72,12 +72,13 @@ SOLVER FLAG[-s] Set maze solving algorithm.
     [dark[algorithm]-[game]] - A mystery...
 
 WALL FLAG[-w] Set the wall style for the maze.
+    [sharp] - Half size walls and paths.
     [sharp] - The default straight lines.
     [round] - Rounded corners.
     [doubles] - Sharp double lines.
     [bold] - Thicker straight lines.
     [contrast] - Full block width and height walls.
-    [half] - Half block height and full width squares.
+    [half] - Half wall height and full size paths.
     [spikes] - Connected lines with spikes.
 
 SOLVER ANIMATION FLAG[-sa] Watch the maze solution.
@@ -116,7 +117,7 @@ The underlying principles for this program are as follows.
 
 I included as many **interesting** maze building algorithms as I could. The solving algorithms are multi-threaded in many cases. This is not particularly practical or special on its own. However, multithreading allows for more fun and interesting visualizations and can speed up what can sometimes be a slow solving process to watch for a single thread.
 
-While I have not yet put together a testing suite for performance testing of building and solving the mazes, I will be interested to see the performance implications of the solvers. Please read the [wiki](https://github.com/agl-alexglopez/maze-tui/wiki) for a much more in depth discussion of algorithms and design processes. That is likely where you will find documentation of new features or other testing.
+While I have not yet put together a testing suite for performance testing of building and solving the mazes, I will be interested to see the performance implications of the solvers. The [wiki](https://github.com/agl-alexglopez/maze-tui/wiki) is likely where you will find documentation of new features or other testing.
 
 ## Wiki
 

--- a/maze_progs/builders/src/arena.rs
+++ b/maze_progs/builders/src/arena.rs
@@ -25,3 +25,18 @@ pub fn animate_maze(maze: &mut maze::Maze, speed: speed::Speed) {
         }
     }
 }
+
+pub fn animate_mini_maze(maze: &mut maze::Maze, speed: speed::Speed) {
+    let animation = build::BUILDER_SPEEDS[speed as usize];
+    build::fill_maze_with_walls(maze);
+    build::flush_grid(maze);
+    build::print_overlap_key_animated(maze);
+    for r in 1..maze.row_size() - 1 {
+        if maze.exit() {
+            return;
+        }
+        for c in 1..maze.col_size() - 1 {
+            build::carve_mini_walls_animated(maze, maze::Point { row: r, col: c }, animation)
+        }
+    }
+}

--- a/maze_progs/builders/src/arena.rs
+++ b/maze_progs/builders/src/arena.rs
@@ -12,6 +12,10 @@ pub fn generate_maze(maze: &mut maze::Maze) {
 }
 
 pub fn animate_maze(maze: &mut maze::Maze, speed: speed::Speed) {
+    if maze.is_mini() {
+        animate_mini_maze(maze, speed);
+        return;
+    }
     let animation = build::BUILDER_SPEEDS[speed as usize];
     build::fill_maze_with_walls(maze);
     build::flush_grid(maze);
@@ -26,7 +30,7 @@ pub fn animate_maze(maze: &mut maze::Maze, speed: speed::Speed) {
     }
 }
 
-pub fn animate_mini_maze(maze: &mut maze::Maze, speed: speed::Speed) {
+fn animate_mini_maze(maze: &mut maze::Maze, speed: speed::Speed) {
     let animation = build::BUILDER_SPEEDS[speed as usize];
     build::fill_maze_with_walls(maze);
     build::flush_grid(maze);

--- a/maze_progs/builders/src/build.rs
+++ b/maze_progs/builders/src/build.rs
@@ -23,8 +23,8 @@ pub enum ParityPoint {
 
 #[derive(Copy, Clone)]
 pub struct BacktrackSymbol {
-    arrow: char,
-    ansi: u8,
+    pub arrow: char,
+    pub ansi: u8,
 }
 
 // Any builders that choose to cache seen squares in place can use this bit.

--- a/maze_progs/builders/src/build.rs
+++ b/maze_progs/builders/src/build.rs
@@ -65,6 +65,7 @@ pub static BACKTRACKING_SYMBOLS: [BacktrackSymbol; 5] = [
         ansi: 4,
     },
 ];
+
 pub const BACKTRACKING_POINTS: [maze::Point; 5] = [
     maze::Point { row: 0, col: 0 },
     maze::Point { row: -2, col: 0 },
@@ -94,22 +95,7 @@ pub const GENERATE_DIRECTIONS: [maze::Point; 4] = [
 // Control the speed steps of animation in microseconds here.
 pub const BUILDER_SPEEDS: [SpeedUnit; 8] = [0, 5000, 2500, 1000, 500, 250, 100, 1];
 
-// Maze Modification Helpers
-
-pub fn build_wall_outline(maze: &mut maze::Maze) {
-    for r in 0..maze.row_size() {
-        for c in 0..maze.col_size() {
-            if c == 0 || c == maze.col_size() - 1 || r == 0 || r == maze.row_size() - 1 {
-                maze[r as usize][c as usize] |= BUILDER_BIT;
-                build_wall_carefully(maze, maze::Point { row: r, col: c });
-                continue;
-            }
-            build_path(maze, maze::Point { row: r, col: c });
-        }
-    }
-}
-
-// Maze Bound Checking
+/// MAZE BOUNDS CHECKING-------------------------------------------------------
 
 pub fn choose_arbitrary_point(maze: &maze::Maze, parity: ParityPoint) -> Option<maze::Point> {
     let init = if parity == ParityPoint::Even { 2 } else { 1 };
@@ -158,7 +144,20 @@ pub fn is_square_within_perimeter_walls(maze: &maze::Maze, next: maze::Point) ->
     next.row < maze.row_size() - 1 && next.row > 0 && next.col < maze.col_size() - 1 && next.col > 0
 }
 
-// Wall Adder Helpers
+/// WALL ADDER HELPERS-------------------------------------------------------------------
+
+pub fn build_wall_outline(maze: &mut maze::Maze) {
+    for r in 0..maze.row_size() {
+        for c in 0..maze.col_size() {
+            if c == 0 || c == maze.col_size() - 1 || r == 0 || r == maze.row_size() - 1 {
+                maze[r as usize][c as usize] |= BUILDER_BIT;
+                build_wall_carefully(maze, maze::Point { row: r, col: c });
+                continue;
+            }
+            build_path(maze, maze::Point { row: r, col: c });
+        }
+    }
+}
 
 pub fn build_wall_line(maze: &mut maze::Maze, p: maze::Point) {
     let u_row = p.row as usize;
@@ -250,7 +249,15 @@ pub fn build_wall_line_animated(maze: &mut maze::Maze, p: maze::Point, speed: Sp
     thread::sleep(time::Duration::from_micros(speed));
 }
 
-// Path Carving Helpers
+/// PATH CARVING HELPERS-------------------------------------------------------------------
+
+pub fn fill_maze_with_walls(maze: &mut maze::Maze) {
+    for r in 0..maze.row_size() {
+        for c in 0..maze.col_size() {
+            build_wall(maze, maze::Point { row: r, col: c });
+        }
+    }
+}
 
 pub fn mark_origin(maze: &mut maze::Maze, walk: maze::Point, next: maze::Point) {
     let u_next_row = next.row as usize;
@@ -296,14 +303,6 @@ pub fn mark_origin_animated(
     thread::sleep(time::Duration::from_micros(speed));
     flush_cursor_maze_coordinate(maze, next);
     thread::sleep(time::Duration::from_micros(speed));
-}
-
-pub fn fill_maze_with_walls(maze: &mut maze::Maze) {
-    for r in 0..maze.row_size() {
-        for c in 0..maze.col_size() {
-            build_wall(maze, maze::Point { row: r, col: c });
-        }
-    }
 }
 
 pub fn carve_path_walls(maze: &mut maze::Maze, p: maze::Point) {
@@ -376,6 +375,65 @@ pub fn carve_path_walls_animated(maze: &mut maze::Maze, p: maze::Point, speed: S
     }
 }
 
+pub fn carve_mini_walls_animated(maze: &mut maze::Maze, p: maze::Point, speed: SpeedUnit) {
+    let u_row = p.row as usize;
+    let u_col = p.col as usize;
+    maze[u_row][u_col] |= maze::PATH_BIT | BUILDER_BIT;
+    print::set_cursor_position(
+        maze::Point {
+            row: (p.row) / 2,
+            col: p.col,
+        },
+        maze.offset(),
+    );
+    flush_mini_backtracker_coordinate(maze, p);
+    thread::sleep(time::Duration::from_micros(speed));
+    if p.row > 0 && (maze[u_row - 1][u_col] & maze::PATH_BIT) == 0 {
+        maze[u_row - 1][u_col] &= !maze::SOUTH_WALL;
+        flush_mini_backtracker_coordinate(
+            maze,
+            maze::Point {
+                row: p.row - 1,
+                col: p.col,
+            },
+        );
+        thread::sleep(time::Duration::from_micros(speed));
+    }
+    if p.row + 1 < maze.row_size() && (maze[u_row + 1][u_col] & maze::PATH_BIT) == 0 {
+        maze[u_row + 1][u_col] &= !maze::NORTH_WALL;
+        flush_mini_backtracker_coordinate(
+            maze,
+            maze::Point {
+                row: p.row + 1,
+                col: p.col,
+            },
+        );
+        thread::sleep(time::Duration::from_micros(speed));
+    }
+    if p.col > 0 && (maze[u_row][u_col - 1] & maze::PATH_BIT) == 0 {
+        maze[u_row][u_col - 1] &= !maze::EAST_WALL;
+        flush_mini_backtracker_coordinate(
+            maze,
+            maze::Point {
+                row: p.row,
+                col: p.col - 1,
+            },
+        );
+        thread::sleep(time::Duration::from_micros(speed));
+    }
+    if p.col + 1 < maze.col_size() && (maze[u_row][u_col + 1] & maze::PATH_BIT) == 0 {
+        maze[u_row][u_col + 1] &= !maze::WEST_WALL;
+        flush_mini_backtracker_coordinate(
+            maze,
+            maze::Point {
+                row: p.row,
+                col: p.col + 1,
+            },
+        );
+        thread::sleep(time::Duration::from_micros(speed));
+    }
+}
+
 pub fn carve_path_markings(maze: &mut maze::Maze, cur: maze::Point, next: maze::Point) {
     let u_next_row = next.row as usize;
     let u_next_col = next.col as usize;
@@ -433,6 +491,39 @@ pub fn carve_path_markings_animated(
     carve_path_walls_animated(maze, wall, speed);
 }
 
+pub fn carve_mini_markings_animated(
+    maze: &mut maze::Maze,
+    cur: maze::Point,
+    next: maze::Point,
+    speed: SpeedUnit,
+) {
+    let u_next_row = next.row as usize;
+    let u_next_col = next.col as usize;
+    let mut wall: maze::Point = cur;
+    if next.row < cur.row {
+        wall.row -= 1;
+        maze[wall.row as usize][wall.col as usize] |= FROM_SOUTH;
+        maze[u_next_row][u_next_col] |= FROM_SOUTH;
+    } else if next.row > cur.row {
+        wall.row += 1;
+        maze[wall.row as usize][wall.col as usize] |= FROM_NORTH;
+        maze[u_next_row][u_next_col] |= FROM_NORTH;
+    } else if next.col < cur.col {
+        wall.col -= 1;
+        maze[wall.row as usize][wall.col as usize] |= FROM_EAST;
+        maze[u_next_row][u_next_col] |= FROM_EAST;
+    } else if next.col > cur.col {
+        wall.col += 1;
+        maze[wall.row as usize][wall.col as usize] |= FROM_WEST;
+        maze[u_next_row][u_next_col] |= FROM_WEST;
+    } else {
+        print::maze_panic!("Wall break error. Cur: {:?} Next: {:?}", cur, next);
+    }
+    carve_mini_walls_animated(maze, cur, speed);
+    carve_mini_walls_animated(maze, next, speed);
+    carve_mini_walls_animated(maze, wall, speed);
+}
+
 pub fn join_squares(maze: &mut maze::Maze, cur: maze::Point, next: maze::Point) {
     build_path(maze, cur);
     maze[cur.row as usize][cur.col as usize] |= BUILDER_BIT;
@@ -475,6 +566,29 @@ pub fn join_squares_animated(
     carve_path_walls_animated(maze, cur, speed);
     carve_path_walls_animated(maze, wall, speed);
     carve_path_walls_animated(maze, next, speed);
+}
+
+pub fn join_minis_animated(
+    maze: &mut maze::Maze,
+    cur: maze::Point,
+    next: maze::Point,
+    speed: SpeedUnit,
+) {
+    let mut wall = cur;
+    if next.row < cur.row {
+        wall.row -= 1;
+    } else if next.row > cur.row {
+        wall.row += 1;
+    } else if next.col < cur.col {
+        wall.col -= 1;
+    } else if next.col > cur.col {
+        wall.col += 1;
+    } else {
+        print::maze_panic!("Cell join error. Maze won't build");
+    }
+    carve_mini_walls_animated(maze, cur, speed);
+    carve_mini_walls_animated(maze, wall, speed);
+    carve_mini_walls_animated(maze, next, speed);
 }
 
 pub fn build_wall(maze: &mut maze::Maze, p: maze::Point) {
@@ -668,7 +782,7 @@ pub fn flush_cursor_maze_coordinate(maze: &maze::Maze, p: maze::Point) {
     } else if square & maze::PATH_BIT == 0 {
         execute!(
             io::stdout(),
-            Print(maze.wall_style()[(square & maze::WALL_MASK) as usize]),
+            Print(maze.wall_char((square & maze::WALL_MASK) as usize)),
         )
         .expect("Could not print wall.");
     } else if square & maze::PATH_BIT != 0 {
@@ -695,7 +809,7 @@ pub fn print_square(maze: &maze::Maze, p: maze::Point) {
     } else if square & maze::PATH_BIT == 0 {
         queue!(
             io::stdout(),
-            Print(maze.wall_style()[(square & maze::WALL_MASK) as usize]),
+            Print(maze.wall_char((square & maze::WALL_MASK) as usize)),
         )
         .expect("Could not print wall.");
     } else if square & maze::PATH_BIT != 0 {
@@ -703,6 +817,107 @@ pub fn print_square(maze: &maze::Maze, p: maze::Point) {
     } else {
         print::maze_panic!("Printed a maze square without a category.");
     }
+}
+
+pub fn flush_mini_backtracker_coordinate(maze: &maze::Maze, p: maze::Point) {
+    print::set_cursor_position(
+        maze::Point {
+            row: p.row / 2,
+            col: p.col,
+        },
+        maze.offset(),
+    );
+    let square = maze[p.row as usize][p.col as usize];
+    if square & maze::PATH_BIT == 0 {
+        let mut color = 0;
+        if p.row % 2 != 0 && p.row - 1 >= 0 {
+            color = BACKTRACKING_SYMBOLS[((maze[(p.row - 1) as usize][p.col as usize]
+                & MARKERS_MASK)
+                >> MARKER_SHIFT) as usize]
+                .ansi;
+        } else if p.row + 1 < maze.row_size() {
+            color = BACKTRACKING_SYMBOLS[((maze[(p.row + 1) as usize][p.col as usize]
+                & MARKERS_MASK)
+                >> MARKER_SHIFT) as usize]
+                .ansi;
+        }
+        execute!(
+            io::stdout(),
+            SetBackgroundColor(Color::AnsiValue(color)),
+            Print(maze.wall_char((square & maze::WALL_MASK) as usize)),
+            ResetColor
+        )
+        .expect("Could not print.");
+        return;
+    }
+    let path = match p.row - 1 >= 0
+        && (maze[(p.row - 1) as usize][p.col as usize] & maze::PATH_BIT) == 0
+    {
+        true => '▀',
+        false => ' ',
+    };
+    let color = BACKTRACKING_SYMBOLS[((square & MARKERS_MASK) >> MARKER_SHIFT) as usize].ansi;
+    execute!(
+        io::stdout(),
+        SetBackgroundColor(Color::AnsiValue(color)),
+        Print(path),
+        ResetColor
+    )
+    .expect("Could not print.");
+}
+
+pub fn flush_mini_coordinate(maze: &maze::Maze, p: maze::Point) {
+    print::set_cursor_position(
+        maze::Point {
+            row: p.row / 2,
+            col: p.col,
+        },
+        maze.offset(),
+    );
+    let square = maze[p.row as usize][p.col as usize];
+    if square & maze::PATH_BIT == 0 {
+        execute!(
+            io::stdout(),
+            Print(maze.wall_char((square & maze::WALL_MASK) as usize)),
+            ResetColor
+        )
+        .expect("Could not print.");
+        return;
+    }
+    let path = match p.row - 1 >= 0
+        && (maze[(p.row - 1) as usize][p.col as usize] & maze::PATH_BIT) == 0
+    {
+        true => '▀',
+        false => ' ',
+    };
+    execute!(io::stdout(), Print(path), ResetColor).expect("Could not print.");
+}
+
+pub fn print_mini_coordinate(maze: &maze::Maze, p: maze::Point) {
+    print::set_cursor_position(
+        maze::Point {
+            row: p.row / 2,
+            col: p.col,
+        },
+        maze.offset(),
+    );
+    let square = maze[p.row as usize][p.col as usize];
+    if square & maze::PATH_BIT == 0 {
+        queue!(
+            io::stdout(),
+            Print(maze.wall_char((square & maze::WALL_MASK) as usize)),
+            ResetColor
+        )
+        .expect("Could not print.");
+        return;
+    }
+    let path = match p.row - 1 >= 0
+        && (maze[(p.row - 1) as usize][p.col as usize] & maze::PATH_BIT) == 0
+    {
+        true => '▀',
+        false => ' ',
+    };
+    queue!(io::stdout(), Print(path), ResetColor).expect("Could not print.");
 }
 
 pub fn flush_grid(maze: &maze::Maze) {
@@ -713,6 +928,19 @@ pub fn flush_grid(maze: &maze::Maze) {
         match queue!(io::stdout(), Print('\n')) {
             Ok(_) => {}
             Err(_) => maze_panic!("Couldn't print square."),
+        };
+    }
+    print::flush();
+}
+
+pub fn flush_mini_walls(maze: &maze::Maze) {
+    for r in 0..maze.row_size() {
+        for c in 0..maze.col_size() {
+            flush_mini_coordinate(maze, maze::Point { row: r, col: c });
+        }
+        match queue!(io::stdout(), Print('\n')) {
+            Ok(_) => {}
+            Err(_) => print::maze_panic!("Couldn't print square."),
         };
     }
     print::flush();

--- a/maze_progs/builders/src/build.rs
+++ b/maze_progs/builders/src/build.rs
@@ -852,7 +852,11 @@ pub fn build_mini_path_animated(maze: &mut maze::Maze, p: maze::Point, speed: Sp
 
 pub fn print_overlap_key(maze: &maze::Maze) {
     let offset = maze::Offset {
-        add_rows: maze.offset().add_rows + maze.row_size(),
+        add_rows: if maze.style_index() == (maze::MazeStyle::Mini as usize) {
+            maze.offset().add_rows + maze.row_size() / 2 + 1
+        } else {
+            maze.offset().add_rows + maze.row_size()
+        },
         add_cols: maze.offset().add_cols,
     };
     let mut cur_print = 0;
@@ -883,7 +887,11 @@ pub fn print_overlap_key(maze: &maze::Maze) {
 
 pub fn print_overlap_key_animated(maze: &maze::Maze) {
     let offset = maze::Offset {
-        add_rows: maze.offset().add_rows + maze.row_size(),
+        add_rows: if maze.style_index() == (maze::MazeStyle::Mini as usize) {
+            maze.offset().add_rows + maze.row_size() / 2 + 1
+        } else {
+            maze.offset().add_rows + maze.row_size()
+        },
         add_cols: maze.offset().add_cols,
     };
     let mut cur_print = 0;

--- a/maze_progs/builders/src/eller.rs
+++ b/maze_progs/builders/src/eller.rs
@@ -142,6 +142,10 @@ pub fn generate_maze(maze: &mut maze::Maze) {
 }
 
 pub fn animate_maze(maze: &mut maze::Maze, speed: speed::Speed) {
+    if maze.is_mini() {
+        animate_mini_maze(maze, speed);
+        return;
+    }
     let animation = build::BUILDER_SPEEDS[speed as usize];
     build::fill_maze_with_walls(maze);
     build::flush_grid(maze);
@@ -213,7 +217,7 @@ pub fn animate_maze(maze: &mut maze::Maze, speed: speed::Speed) {
     complete_final_row_animated(maze, &mut window, animation);
 }
 
-pub fn animate_mini_maze(maze: &mut maze::Maze, speed: speed::Speed) {
+fn animate_mini_maze(maze: &mut maze::Maze, speed: speed::Speed) {
     let animation = build::BUILDER_SPEEDS[speed as usize];
     build::fill_maze_with_walls(maze);
     build::flush_grid(maze);

--- a/maze_progs/builders/src/grid.rs
+++ b/maze_progs/builders/src/grid.rs
@@ -80,6 +80,43 @@ pub fn animate_maze(maze: &mut maze::Maze, speed: speed::Speed) {
     }
 }
 
+pub fn animate_mini_maze(maze: &mut maze::Maze, speed: speed::Speed) {
+    let animation = build::BUILDER_SPEEDS[speed as usize];
+    build::fill_maze_with_walls(maze);
+    build::flush_grid(maze);
+    build::print_overlap_key_animated(maze);
+    let mut rng = thread_rng();
+    let mut dfs: Vec<maze::Point> = Vec::from([maze::Point {
+        row: 2 * (rng.gen_range(1..maze.row_size() - 1) / 2) + 1,
+        col: 2 * (rng.gen_range(1..maze.col_size() - 1) / 2) + 1,
+    }]);
+    let mut random_direction_indices: Vec<usize> = (0..build::NUM_DIRECTIONS).collect();
+    while let Some(run) = dfs.last().cloned() {
+        if maze.exit() {
+            return;
+        }
+        random_direction_indices.shuffle(&mut rng);
+        let mut branches = false;
+        for &i in random_direction_indices.iter() {
+            let p = build::GENERATE_DIRECTIONS[i];
+            let next = maze::Point {
+                row: run.row + p.row,
+                col: run.col + p.col,
+            };
+            if build::can_build_new_square(maze, next) {
+                animate_mini_run(maze, &mut dfs, RunStart { cur: run, dir: p }, animation);
+                branches = true;
+                break;
+            }
+        }
+        if !branches {
+            build::flush_mini_coordinate(maze, run);
+            thread::sleep(time::Duration::from_micros(animation));
+            dfs.pop();
+        }
+    }
+}
+
 // Private Helper Functions-----------------------------------------------------------------------
 
 fn complete_run(maze: &mut maze::Maze, dfs: &mut Vec<maze::Point>, mut run: RunStart) {
@@ -111,6 +148,27 @@ fn animate_run(
     let mut cur_run = 0;
     while build::is_square_within_perimeter_walls(maze, next) && cur_run < RUN_LIMIT {
         build::join_squares_animated(maze, run.cur, next, animation);
+        dfs.push(next);
+        run.cur = next;
+        next.row += run.dir.row;
+        next.col += run.dir.col;
+        cur_run += 1;
+    }
+}
+
+fn animate_mini_run(
+    maze: &mut maze::Maze,
+    dfs: &mut Vec<maze::Point>,
+    mut run: RunStart,
+    animation: build::SpeedUnit,
+) {
+    let mut next = maze::Point {
+        row: run.cur.row + run.dir.row,
+        col: run.cur.col + run.dir.col,
+    };
+    let mut cur_run = 0;
+    while build::is_square_within_perimeter_walls(maze, next) && cur_run < RUN_LIMIT {
+        build::join_minis_animated(maze, run.cur, next, animation);
         dfs.push(next);
         run.cur = next;
         next.row += run.dir.row;

--- a/maze_progs/builders/src/grid.rs
+++ b/maze_progs/builders/src/grid.rs
@@ -44,6 +44,10 @@ pub fn generate_maze(maze: &mut maze::Maze) {
 }
 
 pub fn animate_maze(maze: &mut maze::Maze, speed: speed::Speed) {
+    if maze.is_mini() {
+        animate_mini_maze(maze, speed);
+        return;
+    }
     let animation = build::BUILDER_SPEEDS[speed as usize];
     build::fill_maze_with_walls(maze);
     build::flush_grid(maze);
@@ -80,7 +84,7 @@ pub fn animate_maze(maze: &mut maze::Maze, speed: speed::Speed) {
     }
 }
 
-pub fn animate_mini_maze(maze: &mut maze::Maze, speed: speed::Speed) {
+fn animate_mini_maze(maze: &mut maze::Maze, speed: speed::Speed) {
     let animation = build::BUILDER_SPEEDS[speed as usize];
     build::fill_maze_with_walls(maze);
     build::flush_grid(maze);

--- a/maze_progs/builders/src/kruskal.rs
+++ b/maze_progs/builders/src/kruskal.rs
@@ -53,6 +53,10 @@ pub fn generate_maze(maze: &mut maze::Maze) {
 }
 
 pub fn animate_maze(maze: &mut maze::Maze, speed: speed::Speed) {
+    if maze.is_mini() {
+        animate_mini_maze(maze, speed);
+        return;
+    }
     let animation = build::BUILDER_SPEEDS[speed as usize];
     build::fill_maze_with_walls(maze);
     build::flush_grid(maze);
@@ -100,7 +104,7 @@ pub fn animate_maze(maze: &mut maze::Maze, speed: speed::Speed) {
     }
 }
 
-pub fn animate_mini_maze(maze: &mut maze::Maze, speed: speed::Speed) {
+fn animate_mini_maze(maze: &mut maze::Maze, speed: speed::Speed) {
     let animation = build::BUILDER_SPEEDS[speed as usize];
     build::fill_maze_with_walls(maze);
     build::flush_grid(maze);

--- a/maze_progs/builders/src/kruskal.rs
+++ b/maze_progs/builders/src/kruskal.rs
@@ -100,6 +100,54 @@ pub fn animate_maze(maze: &mut maze::Maze, speed: speed::Speed) {
     }
 }
 
+pub fn animate_mini_maze(maze: &mut maze::Maze, speed: speed::Speed) {
+    let animation = build::BUILDER_SPEEDS[speed as usize];
+    build::fill_maze_with_walls(maze);
+    build::flush_grid(maze);
+    build::print_overlap_key_animated(maze);
+    let walls = load_shuffled_walls(maze);
+    let ids = tag_cells(maze);
+    let mut sets = disjoint::DisjointSet::new(ids.len());
+
+    for w in &walls {
+        if maze.exit() {
+            return;
+        }
+        if w.row % 2 == 0 {
+            let above = maze::Point {
+                row: w.row - 1,
+                col: w.col,
+            };
+            let below = maze::Point {
+                row: w.row + 1,
+                col: w.col,
+            };
+            if let (Some(a_id), Some(b_id)) = (ids.get(&above), ids.get(&below)) {
+                if sets.made_union(*a_id, *b_id) {
+                    build::join_minis_animated(maze, above, below, animation);
+                }
+                continue;
+            }
+            print::maze_panic!("Kruskal couldn't find a cell id. Build broke.");
+        }
+        let left = maze::Point {
+            row: w.row,
+            col: w.col - 1,
+        };
+        let right = maze::Point {
+            row: w.row,
+            col: w.col + 1,
+        };
+        if let (Some(l_id), Some(r_id)) = (ids.get(&left), ids.get(&right)) {
+            if sets.made_union(*l_id, *r_id) {
+                build::join_minis_animated(maze, left, right, animation);
+            }
+            continue;
+        }
+        print::maze_panic!("Kruskal couldn't find a cell id. Build broke.");
+    }
+}
+
 // Private Helper Functions-----------------------------------------------------------------------
 
 fn load_shuffled_walls(maze: &maze::Maze) -> Vec<maze::Point> {

--- a/maze_progs/builders/src/modify.rs
+++ b/maze_progs/builders/src/modify.rs
@@ -36,6 +36,29 @@ pub fn add_cross_animated(maze: &mut maze::Maze, speed: speed::Speed) {
     }
 }
 
+pub fn add_mini_cross_animated(maze: &mut maze::Maze, speed: speed::Speed) {
+    let animation = build::BUILDER_SPEEDS[speed as usize];
+    for r in 0..maze.row_size() {
+        for c in 0..maze.col_size() {
+            if maze.exit() {
+                return;
+            }
+            if (r == maze.row_size() / 2 && c > 1 && c < maze.col_size() - 2)
+                || (c == maze.col_size() / 2 && r > 1 && r < maze.row_size() - 2)
+            {
+                build::build_mini_path_animated(maze, maze::Point { row: r, col: c }, animation);
+                if c + 1 < maze.col_size() - 2 {
+                    build::build_mini_path_animated(
+                        maze,
+                        maze::Point { row: r, col: c + 1 },
+                        animation,
+                    );
+                }
+            }
+        }
+    }
+}
+
 pub fn add_x(maze: &mut maze::Maze) {
     for r in 1..maze.row_size() - 1 {
         for c in 1..maze.col_size() - 1 {
@@ -54,6 +77,19 @@ pub fn add_x_animated(maze: &mut maze::Maze, speed: speed::Speed) {
             }
             add_positive_slope_animated(maze, maze::Point { row: r, col: c }, animation);
             add_negative_slope_animated(maze, maze::Point { row: r, col: c }, animation);
+        }
+    }
+}
+
+pub fn add_mini_x_animated(maze: &mut maze::Maze, speed: speed::Speed) {
+    let animation: build::SpeedUnit = build::BUILDER_SPEEDS[speed as usize];
+    for r in 1..maze.row_size() - 1 {
+        for c in 1..maze.col_size() - 1 {
+            if maze.exit() {
+                return;
+            }
+            add_mini_positive_slope_animated(maze, maze::Point { row: r, col: c }, animation);
+            add_mini_negative_slope_animated(maze, maze::Point { row: r, col: c }, animation);
         }
     }
 }
@@ -158,6 +194,62 @@ fn add_positive_slope_animated(maze: &mut maze::Maze, p: maze::Point, speed: bui
     }
 }
 
+fn add_mini_positive_slope_animated(
+    maze: &mut maze::Maze,
+    p: maze::Point,
+    speed: build::SpeedUnit,
+) {
+    let row_size = maze.row_size() as f32 - 2.0f32;
+    let col_size = maze.col_size() as f32 - 2.0f32;
+    let cur_row = p.row as f32;
+    let slope = (2.0f32 - row_size) / (2.0f32 - col_size);
+    let b = 2.0f32 - (2.0f32 * slope);
+    let on_slope = ((cur_row - b) / slope) as i32;
+    if p.col == on_slope && p.col < maze.col_size() - 2 && p.col > 1 {
+        build::build_mini_path_animated(maze, p, speed);
+        if p.col + 1 < maze.col_size() - 2 {
+            build::build_mini_path_animated(
+                maze,
+                maze::Point {
+                    row: p.row,
+                    col: p.col + 1,
+                },
+                speed,
+            );
+        }
+        if p.col - 1 > 1 {
+            build::build_mini_path_animated(
+                maze,
+                maze::Point {
+                    row: p.row,
+                    col: p.col - 1,
+                },
+                speed,
+            );
+        }
+        if p.col + 2 < maze.col_size() - 2 {
+            build::build_mini_path_animated(
+                maze,
+                maze::Point {
+                    row: p.row,
+                    col: p.col + 2,
+                },
+                speed,
+            );
+        }
+        if p.col - 2 > 1 {
+            build::build_mini_path_animated(
+                maze,
+                maze::Point {
+                    row: p.row,
+                    col: p.col - 2,
+                },
+                speed,
+            );
+        }
+    }
+}
+
 fn add_negative_slope(maze: &mut maze::Maze, p: maze::Point) {
     let row_size = maze.row_size() as f32 - 2.0f32;
     let col_size = maze.col_size() as f32 - 2.0f32;
@@ -247,6 +339,62 @@ fn add_negative_slope_animated(maze: &mut maze::Maze, p: maze::Point, speed: bui
         }
         if p.col - 2 > 1 {
             build::build_path_animated(
+                maze,
+                maze::Point {
+                    row: p.row,
+                    col: p.col - 2,
+                },
+                speed,
+            );
+        }
+    }
+}
+
+fn add_mini_negative_slope_animated(
+    maze: &mut maze::Maze,
+    p: maze::Point,
+    speed: build::SpeedUnit,
+) {
+    let row_size = maze.row_size() as f32 - 2.0f32;
+    let col_size = maze.col_size() as f32 - 2.0f32;
+    let cur_row = p.row as f32;
+    let slope = (2.0f32 - row_size) / (col_size - 2.0f32);
+    let b = row_size - (2.0f32 * slope);
+    let on_line = ((cur_row - b) / slope) as i32;
+    if p.col == on_line && p.col > 1 && p.col < maze.col_size() - 2 && p.row < maze.row_size() - 2 {
+        build::build_mini_path_animated(maze, p, speed);
+        if p.col + 1 < maze.col_size() - 2 {
+            build::build_mini_path_animated(
+                maze,
+                maze::Point {
+                    row: p.row,
+                    col: p.col + 1,
+                },
+                speed,
+            );
+        }
+        if p.col - 1 > 1 {
+            build::build_mini_path_animated(
+                maze,
+                maze::Point {
+                    row: p.row,
+                    col: p.col - 1,
+                },
+                speed,
+            );
+        }
+        if p.col + 2 < maze.col_size() - 2 {
+            build::build_mini_path_animated(
+                maze,
+                maze::Point {
+                    row: p.row,
+                    col: p.col + 2,
+                },
+                speed,
+            );
+        }
+        if p.col - 2 > 1 {
+            build::build_mini_path_animated(
                 maze,
                 maze::Point {
                     row: p.row,

--- a/maze_progs/builders/src/modify.rs
+++ b/maze_progs/builders/src/modify.rs
@@ -18,6 +18,10 @@ pub fn add_cross(maze: &mut maze::Maze) {
 }
 
 pub fn add_cross_animated(maze: &mut maze::Maze, speed: speed::Speed) {
+    if maze.is_mini() {
+        add_mini_cross_animated(maze, speed);
+        return;
+    }
     let animation = build::BUILDER_SPEEDS[speed as usize];
     for r in 0..maze.row_size() {
         for c in 0..maze.col_size() {
@@ -36,7 +40,7 @@ pub fn add_cross_animated(maze: &mut maze::Maze, speed: speed::Speed) {
     }
 }
 
-pub fn add_mini_cross_animated(maze: &mut maze::Maze, speed: speed::Speed) {
+fn add_mini_cross_animated(maze: &mut maze::Maze, speed: speed::Speed) {
     let animation = build::BUILDER_SPEEDS[speed as usize];
     for r in 0..maze.row_size() {
         for c in 0..maze.col_size() {
@@ -69,6 +73,10 @@ pub fn add_x(maze: &mut maze::Maze) {
 }
 
 pub fn add_x_animated(maze: &mut maze::Maze, speed: speed::Speed) {
+    if maze.is_mini() {
+        add_mini_x_animated(maze, speed);
+        return;
+    }
     let animation: build::SpeedUnit = build::BUILDER_SPEEDS[speed as usize];
     for r in 1..maze.row_size() - 1 {
         for c in 1..maze.col_size() - 1 {
@@ -81,7 +89,7 @@ pub fn add_x_animated(maze: &mut maze::Maze, speed: speed::Speed) {
     }
 }
 
-pub fn add_mini_x_animated(maze: &mut maze::Maze, speed: speed::Speed) {
+fn add_mini_x_animated(maze: &mut maze::Maze, speed: speed::Speed) {
     let animation: build::SpeedUnit = build::BUILDER_SPEEDS[speed as usize];
     for r in 1..maze.row_size() - 1 {
         for c in 1..maze.col_size() - 1 {

--- a/maze_progs/builders/src/prim.rs
+++ b/maze_progs/builders/src/prim.rs
@@ -85,6 +85,10 @@ pub fn generate_maze(maze: &mut maze::Maze) {
 }
 
 pub fn animate_maze(maze: &mut maze::Maze, speed: speed::Speed) {
+    if maze.is_mini() {
+        animate_mini_maze(maze, speed);
+        return;
+    }
     let animation = build::BUILDER_SPEEDS[speed as usize];
     build::fill_maze_with_walls(maze);
     build::flush_grid(maze);
@@ -137,7 +141,7 @@ pub fn animate_maze(maze: &mut maze::Maze, speed: speed::Speed) {
     }
 }
 
-pub fn animate_mini_maze(maze: &mut maze::Maze, speed: speed::Speed) {
+fn animate_mini_maze(maze: &mut maze::Maze, speed: speed::Speed) {
     let animation = build::BUILDER_SPEEDS[speed as usize];
     build::fill_maze_with_walls(maze);
     build::flush_grid(maze);

--- a/maze_progs/builders/src/prim.rs
+++ b/maze_progs/builders/src/prim.rs
@@ -136,3 +136,56 @@ pub fn animate_maze(maze: &mut maze::Maze, speed: speed::Speed) {
         };
     }
 }
+
+pub fn animate_mini_maze(maze: &mut maze::Maze, speed: speed::Speed) {
+    let animation = build::BUILDER_SPEEDS[speed as usize];
+    build::fill_maze_with_walls(maze);
+    build::flush_grid(maze);
+    build::print_overlap_key_animated(maze);
+    let mut rng = thread_rng();
+    let weight_range = Uniform::from(1..=100);
+    let start = PriorityPoint {
+        priority: weight_range.sample(&mut rng),
+        p: maze::Point {
+            row: 2 * rng.gen_range(1..((maze.row_size() - 2) / 2)) + 1,
+            col: 2 * rng.gen_range(1..((maze.col_size() - 2) / 2)) + 1,
+        },
+    };
+    let mut lookup_weights: HashMap<maze::Point, u8> = HashMap::from([(start.p, start.priority)]);
+    let mut pq = BinaryHeap::from([start]);
+    while let Some(&cur) = pq.peek() {
+        if maze.exit() {
+            return;
+        }
+        let mut max_neighbor: Option<PriorityPoint> = None;
+        let mut max_weight = 0;
+        for dir in &build::GENERATE_DIRECTIONS {
+            let next = maze::Point {
+                row: cur.p.row + dir.row,
+                col: cur.p.col + dir.col,
+            };
+            if !build::can_build_new_square(maze, next) {
+                continue;
+            }
+            let weight = *lookup_weights
+                .entry(next)
+                .or_insert(weight_range.sample(&mut rng));
+            if weight > max_weight {
+                max_weight = weight;
+                max_neighbor.replace(PriorityPoint {
+                    priority: weight,
+                    p: next,
+                });
+            }
+        }
+        match max_neighbor {
+            Some(neighbor) => {
+                build::join_minis_animated(maze, cur.p, neighbor.p, animation);
+                pq.push(neighbor);
+            }
+            None => {
+                pq.pop();
+            }
+        };
+    }
+}

--- a/maze_progs/builders/src/recursive_backtracker.rs
+++ b/maze_progs/builders/src/recursive_backtracker.rs
@@ -100,7 +100,7 @@ pub fn animate_maze(maze: &mut maze::Maze, speed: speed::Speed) {
 pub fn animate_mini_maze(maze: &mut maze::Maze, speed: speed::Speed) {
     let animation: build::SpeedUnit = build::BUILDER_SPEEDS[speed as usize];
     build::fill_maze_with_walls(maze);
-    build::flush_mini_walls(maze);
+    build::flush_grid(maze);
     let mut gen = thread_rng();
     let start: maze::Point = maze::Point {
         row: 2 * (gen.gen_range(1..maze.row_size() - 2) / 2) + 1,
@@ -136,13 +136,6 @@ pub fn animate_mini_maze(maze: &mut maze::Maze, speed: speed::Speed) {
         };
         maze[cur.row as usize][cur.col as usize] &= !build::MARKERS_MASK;
         maze[half_step.row as usize][half_step.col as usize] &= !build::MARKERS_MASK;
-        print::set_cursor_position(
-            maze::Point {
-                row: half_step.row / 2,
-                col: half_step.col,
-            },
-            maze.offset(),
-        );
         build::flush_mini_backtracker_coordinate(maze, half_step);
         thread::sleep(time::Duration::from_micros(animation * BACKTRACK_DELAY));
         build::flush_mini_backtracker_coordinate(maze, cur);

--- a/maze_progs/builders/src/recursive_backtracker.rs
+++ b/maze_progs/builders/src/recursive_backtracker.rs
@@ -101,6 +101,7 @@ pub fn animate_mini_maze(maze: &mut maze::Maze, speed: speed::Speed) {
     let animation: build::SpeedUnit = build::BUILDER_SPEEDS[speed as usize];
     build::fill_maze_with_walls(maze);
     build::flush_grid(maze);
+    build::print_overlap_key_animated(maze);
     let mut gen = thread_rng();
     let start: maze::Point = maze::Point {
         row: 2 * (gen.gen_range(1..maze.row_size() - 2) / 2) + 1,

--- a/maze_progs/builders/src/recursive_backtracker.rs
+++ b/maze_progs/builders/src/recursive_backtracker.rs
@@ -2,8 +2,12 @@ use crate::build;
 use maze;
 use speed;
 
+use crossterm::{
+    execute, queue,
+    style::{Color, Print, ResetColor, SetBackgroundColor},
+};
 use rand::{seq::SliceRandom, thread_rng, Rng};
-use std::{thread, time};
+use std::{self, io, thread, time};
 
 // Backtracking was too fast because it just clears square. Slow down for animation.
 const BACKTRACK_DELAY: build::SpeedUnit = 8;
@@ -95,5 +99,307 @@ pub fn animate_maze(maze: &mut maze::Maze, speed: speed::Speed) {
         if cur == start {
             return;
         }
+    }
+}
+
+pub fn animate_mini_maze(maze: &mut maze::Maze, speed: speed::Speed) {
+    let animation: build::SpeedUnit = build::BUILDER_SPEEDS[speed as usize];
+    build::fill_maze_with_walls(maze);
+    flush_grid(maze);
+    let mut gen = thread_rng();
+    let start: maze::Point = maze::Point {
+        row: 2 * (gen.gen_range(1..maze.row_size() - 2) / 2) + 1,
+        col: 2 * (gen.gen_range(1..maze.col_size() - 2) / 2) + 1,
+    };
+    let mut random_direction_indices: Vec<usize> = (0..build::NUM_DIRECTIONS).collect();
+    let mut cur: maze::Point = start;
+    'branching: loop {
+        if maze.exit() {
+            return;
+        }
+        random_direction_indices.shuffle(&mut gen);
+        for &i in random_direction_indices.iter() {
+            let direction = &build::GENERATE_DIRECTIONS[i];
+            let branch = maze::Point {
+                row: cur.row + direction.row,
+                col: cur.col + direction.col,
+            };
+            if build::can_build_new_square(maze, branch) {
+                carve_path_markings_animated(maze, cur, branch, animation);
+                cur = branch;
+                continue 'branching;
+            }
+        }
+        let dir: build::BacktrackMarker =
+            (maze[cur.row as usize][cur.col as usize] & build::MARKERS_MASK) >> build::MARKER_SHIFT;
+        // The solvers will need these bits later so we need to clear bits.
+        let backtracking: &maze::Point = &build::BACKTRACKING_POINTS[dir as usize];
+        let half: &maze::Point = &build::BACKTRACKING_HALF_POINTS[dir as usize];
+        let half_step = maze::Point {
+            row: cur.row + half.row,
+            col: cur.col + half.col,
+        };
+        maze[cur.row as usize][cur.col as usize] &= !build::MARKERS_MASK;
+        maze[half_step.row as usize][half_step.col as usize] &= !build::MARKERS_MASK;
+        print::set_cursor_position(
+            maze::Point {
+                row: half_step.row / 2,
+                col: half_step.col,
+            },
+            maze.offset(),
+        );
+        flush_cursor_maze_coordinate(maze, half_step);
+        thread::sleep(time::Duration::from_micros(animation * BACKTRACK_DELAY));
+        print::set_cursor_position(
+            maze::Point {
+                row: cur.row / 2,
+                col: cur.col,
+            },
+            maze.offset(),
+        );
+        flush_cursor_maze_coordinate(maze, cur);
+        thread::sleep(time::Duration::from_micros(animation * BACKTRACK_DELAY));
+        cur.row += backtracking.row;
+        cur.col += backtracking.col;
+
+        if cur == start {
+            return;
+        }
+    }
+}
+
+fn flush_grid(maze: &maze::Maze) {
+    for r in 0..(maze.row_size() + 2 - 1) / 2 {
+        for c in 0..maze.col_size() {
+            if r == ((maze.row_size() + 2 - 1) / 2) - 1 {
+                print::set_cursor_position(maze::Point { row: r, col: c }, maze.offset());
+                queue!(io::stdout(), Print('▀'),).expect("Could not print wall.");
+            } else {
+                print::set_cursor_position(maze::Point { row: r, col: c }, maze.offset());
+                queue!(io::stdout(), Print('█'),).expect("Could not print wall.");
+            }
+        }
+        match queue!(io::stdout(), Print('\n')) {
+            Ok(_) => {}
+            Err(_) => print::maze_panic!("Couldn't print square."),
+        };
+    }
+    print::flush();
+}
+
+fn carve_path_markings_animated(
+    maze: &mut maze::Maze,
+    cur: maze::Point,
+    next: maze::Point,
+    speed: build::SpeedUnit,
+) {
+    let u_next_row = next.row as usize;
+    let u_next_col = next.col as usize;
+    let mut wall: maze::Point = cur;
+    if next.row < cur.row {
+        wall.row -= 1;
+        maze[wall.row as usize][wall.col as usize] |= build::FROM_SOUTH;
+        maze[u_next_row][u_next_col] |= build::FROM_SOUTH;
+    } else if next.row > cur.row {
+        wall.row += 1;
+        maze[wall.row as usize][wall.col as usize] |= build::FROM_NORTH;
+        maze[u_next_row][u_next_col] |= build::FROM_NORTH;
+    } else if next.col < cur.col {
+        wall.col -= 1;
+        maze[wall.row as usize][wall.col as usize] |= build::FROM_EAST;
+        maze[u_next_row][u_next_col] |= build::FROM_EAST;
+    } else if next.col > cur.col {
+        wall.col += 1;
+        maze[wall.row as usize][wall.col as usize] |= build::FROM_WEST;
+        maze[u_next_row][u_next_col] |= build::FROM_WEST;
+    } else {
+        print::maze_panic!("Wall break error. Cur: {:?} Next: {:?}", cur, next);
+    }
+    carve_path_walls_animated(maze, cur, speed);
+    carve_path_walls_animated(maze, next, speed);
+    carve_path_walls_animated(maze, wall, speed);
+}
+
+fn carve_path_walls_animated(maze: &mut maze::Maze, p: maze::Point, speed: build::SpeedUnit) {
+    let u_row = p.row as usize;
+    let u_col = p.col as usize;
+    maze[u_row][u_col] |= maze::PATH_BIT | build::BUILDER_BIT;
+    print::set_cursor_position(
+        maze::Point {
+            row: (p.row) / 2,
+            col: p.col,
+        },
+        maze.offset(),
+    );
+    flush_cursor_maze_coordinate(maze, p);
+    thread::sleep(time::Duration::from_micros(speed));
+    if p.row > 0 && (maze[u_row - 1][u_col] & maze::PATH_BIT) == 0 {
+        maze[u_row - 1][u_col] &= !maze::SOUTH_WALL;
+        print::set_cursor_position(
+            maze::Point {
+                row: (p.row - 1) / 2,
+                col: p.col,
+            },
+            maze.offset(),
+        );
+        flush_cursor_maze_coordinate(
+            maze,
+            maze::Point {
+                row: p.row - 1,
+                col: p.col,
+            },
+        );
+        thread::sleep(time::Duration::from_micros(speed));
+    }
+    if p.row + 1 < maze.row_size() && (maze[u_row + 1][u_col] & maze::PATH_BIT) == 0 {
+        maze[u_row + 1][u_col] &= !maze::NORTH_WALL;
+        print::set_cursor_position(
+            maze::Point {
+                row: (p.row + 1) / 2,
+                col: p.col,
+            },
+            maze.offset(),
+        );
+        flush_cursor_maze_coordinate(
+            maze,
+            maze::Point {
+                row: p.row + 1,
+                col: p.col,
+            },
+        );
+        thread::sleep(time::Duration::from_micros(speed));
+    }
+    if p.col > 0 && (maze[u_row][u_col - 1] & maze::PATH_BIT) == 0 {
+        maze[u_row][u_col - 1] &= !maze::EAST_WALL;
+        print::set_cursor_position(
+            maze::Point {
+                row: (p.row) / 2,
+                col: p.col - 1,
+            },
+            maze.offset(),
+        );
+        flush_cursor_maze_coordinate(
+            maze,
+            maze::Point {
+                row: p.row,
+                col: p.col - 1,
+            },
+        );
+        thread::sleep(time::Duration::from_micros(speed));
+    }
+    if p.col + 1 < maze.col_size() && (maze[u_row][u_col + 1] & maze::PATH_BIT) == 0 {
+        maze[u_row][u_col + 1] &= !maze::WEST_WALL;
+        print::set_cursor_position(
+            maze::Point {
+                row: (p.row) / 2,
+                col: p.col + 1,
+            },
+            maze.offset(),
+        );
+        flush_cursor_maze_coordinate(
+            maze,
+            maze::Point {
+                row: p.row,
+                col: p.col + 1,
+            },
+        );
+        thread::sleep(time::Duration::from_micros(speed));
+    }
+}
+
+fn flush_cursor_maze_coordinate(maze: &maze::Maze, p: maze::Point) {
+    let mut square = maze[p.row as usize][p.col as usize];
+    if square & maze::PATH_BIT == 0 {
+        if p.row % 2 != 0 {
+            if p.row - 1 < 0 {
+                return;
+            }
+            if (maze[(p.row - 1) as usize][p.col as usize] & maze::PATH_BIT) == 0 {
+                execute!(io::stdout(), Print('█'), ResetColor).expect("Could not print.");
+            } else {
+                square = maze[(p.row - 1) as usize][p.col as usize];
+                let mark = build::BACKTRACKING_SYMBOLS
+                    [((square & build::MARKERS_MASK) >> build::MARKER_SHIFT) as usize];
+                execute!(
+                    io::stdout(),
+                    SetBackgroundColor(Color::AnsiValue(mark.ansi)),
+                    Print('▄'),
+                    ResetColor
+                )
+                .expect("Could not print.");
+            }
+        } else {
+            if p.row + 1 >= maze.row_size() {
+                return;
+            }
+            if (maze[(p.row + 1) as usize][p.col as usize] & maze::PATH_BIT) == 0 {
+                execute!(io::stdout(), Print('█'), ResetColor).expect("Could not print.");
+            } else {
+                square = maze[(p.row + 1) as usize][p.col as usize];
+                let mark = build::BACKTRACKING_SYMBOLS
+                    [((square & build::MARKERS_MASK) >> build::MARKER_SHIFT) as usize];
+                execute!(
+                    io::stdout(),
+                    SetBackgroundColor(Color::AnsiValue(mark.ansi)),
+                    Print('▀'),
+                    ResetColor
+                )
+                .expect("Could not print.");
+            }
+        }
+    } else if square & maze::PATH_BIT != 0 {
+        if p.row % 2 != 0 {
+            if p.row - 1 < 0 {
+                return;
+            }
+            if (maze[(p.row - 1) as usize][p.col as usize] & maze::PATH_BIT) != 0 {
+                let mark = build::BACKTRACKING_SYMBOLS
+                    [((square & build::MARKERS_MASK) >> build::MARKER_SHIFT) as usize];
+                execute!(
+                    io::stdout(),
+                    SetBackgroundColor(Color::AnsiValue(mark.ansi)),
+                    Print(' '),
+                    ResetColor
+                )
+                .expect("Could not print.");
+            } else {
+                let mark = build::BACKTRACKING_SYMBOLS
+                    [((square & build::MARKERS_MASK) >> build::MARKER_SHIFT) as usize];
+                execute!(
+                    io::stdout(),
+                    SetBackgroundColor(Color::AnsiValue(mark.ansi)),
+                    Print('▀'),
+                    ResetColor
+                )
+                .expect("Could not print.");
+            }
+        } else {
+            if p.row + 1 >= maze.row_size() {
+                return;
+            }
+            if (maze[(p.row + 1) as usize][p.col as usize] & maze::PATH_BIT) != 0 {
+                let mark = build::BACKTRACKING_SYMBOLS
+                    [((square & build::MARKERS_MASK) >> build::MARKER_SHIFT) as usize];
+                execute!(
+                    io::stdout(),
+                    SetBackgroundColor(Color::AnsiValue(mark.ansi)),
+                    Print(' '),
+                    ResetColor
+                )
+                .expect("Could not print.");
+            } else {
+                let mark = build::BACKTRACKING_SYMBOLS
+                    [((square & build::MARKERS_MASK) >> build::MARKER_SHIFT) as usize];
+                execute!(
+                    io::stdout(),
+                    SetBackgroundColor(Color::AnsiValue(mark.ansi)),
+                    Print(' '),
+                    ResetColor
+                )
+                .expect("Could not print.");
+            }
+        }
+    } else {
+        print::maze_panic!("Printed a maze square without a category.");
     }
 }

--- a/maze_progs/builders/src/recursive_backtracker.rs
+++ b/maze_progs/builders/src/recursive_backtracker.rs
@@ -45,6 +45,10 @@ pub fn generate_maze(maze: &mut maze::Maze) {
 }
 
 pub fn animate_maze(maze: &mut maze::Maze, speed: speed::Speed) {
+    if maze.is_mini() {
+        animate_mini_maze(maze, speed);
+        return;
+    }
     let animation: build::SpeedUnit = build::BUILDER_SPEEDS[speed as usize];
     build::fill_maze_with_walls(maze);
     build::flush_grid(maze);
@@ -97,7 +101,7 @@ pub fn animate_maze(maze: &mut maze::Maze, speed: speed::Speed) {
     }
 }
 
-pub fn animate_mini_maze(maze: &mut maze::Maze, speed: speed::Speed) {
+fn animate_mini_maze(maze: &mut maze::Maze, speed: speed::Speed) {
     let animation: build::SpeedUnit = build::BUILDER_SPEEDS[speed as usize];
     build::fill_maze_with_walls(maze);
     build::flush_grid(maze);

--- a/maze_progs/builders/src/recursive_subdivision.rs
+++ b/maze_progs/builders/src/recursive_subdivision.rs
@@ -164,6 +164,83 @@ pub fn animate_maze(maze: &mut maze::Maze, speed: speed::Speed) {
     }
 }
 
+pub fn animate_mini_maze(maze: &mut maze::Maze, speed: speed::Speed) {
+    let animation = build::BUILDER_SPEEDS[speed as usize];
+    build::build_wall_outline(maze);
+    build::flush_grid(maze);
+    build::print_overlap_key_animated(maze);
+    let mut rng = thread_rng();
+    let mut chamber_stack: Vec<Chamber> = Vec::from([Chamber {
+        offset: maze::Point { row: 0, col: 0 },
+        h: maze.row_size(),
+        w: maze.col_size(),
+    }]);
+    while let Some(chamber) = chamber_stack.pop() {
+        if maze.exit() {
+            return;
+        }
+        if chamber.h >= chamber.w && chamber.w > MIN_CHAMBER {
+            let divide = random_even_div(&mut rng, chamber.h);
+            let passage = rand_odd_pass(&mut rng, chamber.w);
+            for c in 0..chamber.w {
+                if c == passage {
+                    continue;
+                }
+                build::build_mini_wall_line_animated(
+                    maze,
+                    maze::Point {
+                        row: chamber.offset.row + divide,
+                        col: chamber.offset.col + c,
+                    },
+                    animation,
+                );
+            }
+            chamber_stack.push(Chamber {
+                offset: chamber.offset,
+                h: divide + 1,
+                w: chamber.w,
+            });
+            chamber_stack.push(Chamber {
+                offset: maze::Point {
+                    row: chamber.offset.row + divide,
+                    col: chamber.offset.col,
+                },
+                h: chamber.h - divide,
+                w: chamber.w,
+            });
+        } else if chamber.w > chamber.h && chamber.h > MIN_CHAMBER {
+            let divide = random_even_div(&mut rng, chamber.w);
+            let passage = rand_odd_pass(&mut rng, chamber.h);
+            for r in 0..chamber.h {
+                if r == passage {
+                    continue;
+                }
+                build::build_mini_wall_line_animated(
+                    maze,
+                    maze::Point {
+                        row: chamber.offset.row + r,
+                        col: chamber.offset.col + divide,
+                    },
+                    animation,
+                );
+            }
+            chamber_stack.push(Chamber {
+                offset: chamber.offset,
+                h: chamber.h,
+                w: divide + 1,
+            });
+            chamber_stack.push(Chamber {
+                offset: maze::Point {
+                    row: chamber.offset.row,
+                    col: chamber.offset.col + divide,
+                },
+                h: chamber.h,
+                w: chamber.w - divide,
+            });
+        }
+    }
+}
+
 // Private Helpers--------------------------------------------------------------------------------
 
 fn random_even_div(rng: &mut ThreadRng, axis_limit: i32) -> i32 {

--- a/maze_progs/builders/src/recursive_subdivision.rs
+++ b/maze_progs/builders/src/recursive_subdivision.rs
@@ -88,6 +88,10 @@ pub fn generate_maze(maze: &mut maze::Maze) {
 }
 
 pub fn animate_maze(maze: &mut maze::Maze, speed: speed::Speed) {
+    if maze.is_mini() {
+        animate_mini_maze(maze, speed);
+        return;
+    }
     let animation = build::BUILDER_SPEEDS[speed as usize];
     build::build_wall_outline(maze);
     build::flush_grid(maze);
@@ -164,7 +168,7 @@ pub fn animate_maze(maze: &mut maze::Maze, speed: speed::Speed) {
     }
 }
 
-pub fn animate_mini_maze(maze: &mut maze::Maze, speed: speed::Speed) {
+fn animate_mini_maze(maze: &mut maze::Maze, speed: speed::Speed) {
     let animation = build::BUILDER_SPEEDS[speed as usize];
     build::build_wall_outline(maze);
     build::flush_grid(maze);

--- a/maze_progs/builders/src/wilson_adder.rs
+++ b/maze_progs/builders/src/wilson_adder.rs
@@ -108,6 +108,51 @@ pub fn animate_maze(maze: &mut maze::Maze, speed: speed::Speed) {
     }
 }
 
+pub fn animate_mini_maze(maze: &mut maze::Maze, speed: speed::Speed) {
+    let animation = build::BUILDER_SPEEDS[speed as usize];
+    build::build_wall_outline(maze);
+    build::flush_grid(maze);
+    build::print_overlap_key_animated(maze);
+    let mut rng = thread_rng();
+    let mut cur = RandomWalk {
+        prev_row_start: 2,
+        prev: maze::Point { row: 0, col: 0 },
+        walk: maze::Point {
+            row: 2 * (rng.gen_range(2..maze.row_size() - 1) / 2),
+            col: 2 * (rng.gen_range(2..maze.col_size() - 1) / 2),
+        },
+        next: maze::Point { row: 0, col: 0 },
+    };
+    let mut indices: Vec<usize> = (0..build::NUM_DIRECTIONS).collect();
+    'walking: loop {
+        if maze.exit() {
+            return;
+        }
+        maze[cur.walk.row as usize][cur.walk.col as usize] |= WALK_BIT;
+        indices.shuffle(&mut rng);
+        'choosing_step: for &i in indices.iter() {
+            let p = &build::GENERATE_DIRECTIONS[i];
+            cur.next = maze::Point {
+                row: cur.walk.row + p.row,
+                col: cur.walk.col + p.col,
+            };
+            if !is_valid_step(maze, cur.next, cur.prev) {
+                continue 'choosing_step;
+            }
+
+            match complete_mini_walk_animated(maze, cur, animation) {
+                Some(new_walk) => {
+                    cur = new_walk;
+                    continue 'walking;
+                }
+                None => {
+                    return;
+                }
+            }
+        }
+    }
+}
+
 // Private Functions------------------------------------------------------------------------------
 
 fn complete_walk(maze: &mut maze::Maze, mut walk: RandomWalk) -> Option<RandomWalk> {
@@ -201,6 +246,54 @@ fn complete_walk_animated(
     Some(walk)
 }
 
+fn complete_mini_walk_animated(
+    maze: &mut maze::Maze,
+    mut walk: RandomWalk,
+    speed: build::SpeedUnit,
+) -> Option<RandomWalk> {
+    if build::has_builder_bit(maze, walk.next) {
+        build_with_mini_marks_animated(maze, walk.walk, walk.next, speed);
+        connect_mini_walk_animated(maze, walk.walk, speed);
+        match build::choose_point_from_row_start(
+            maze,
+            walk.prev_row_start,
+            build::ParityPoint::Even,
+        ) {
+            Some(point) => {
+                walk.prev_row_start = point.row;
+                walk.walk = point;
+                maze[walk.walk.row as usize][walk.walk.col as usize] &= !build::MARKERS_MASK;
+                walk.prev = maze::Point { row: 0, col: 0 };
+                return Some(walk);
+            }
+            None => {
+                return None;
+            }
+        };
+    }
+    if found_loop(maze, walk.next) {
+        erase_mini_loop_animated(
+            maze,
+            Loop {
+                walk: walk.walk,
+                root: walk.next,
+            },
+            speed,
+        );
+        walk.walk = walk.next;
+        let dir: &'static maze::Point = backtrack_point(maze, &walk.walk);
+        walk.prev = maze::Point {
+            row: walk.walk.row + dir.row,
+            col: walk.walk.col + dir.col,
+        };
+        return Some(walk);
+    }
+    build::mark_mini_origin_animated(maze, walk.walk, walk.next, speed);
+    walk.prev = walk.walk;
+    walk.walk = walk.next;
+    Some(walk)
+}
+
 fn erase_loop(maze: &mut maze::Maze, mut walk: Loop) {
     while walk.walk != walk.root {
         maze[walk.walk.row as usize][walk.walk.col as usize] &= !WALK_BIT;
@@ -232,6 +325,29 @@ fn erase_loop_animated(maze: &mut maze::Maze, mut walk: Loop, speed: build::Spee
         build::flush_cursor_maze_coordinate(maze, half_step);
         thread::sleep(time::Duration::from_micros(speed));
         build::flush_cursor_maze_coordinate(maze, walk.walk);
+        thread::sleep(time::Duration::from_micros(speed));
+        walk.walk = next;
+    }
+}
+
+fn erase_mini_loop_animated(maze: &mut maze::Maze, mut walk: Loop, speed: build::SpeedUnit) {
+    while walk.walk != walk.root {
+        maze[walk.walk.row as usize][walk.walk.col as usize] &= !WALK_BIT;
+        let dir: &'static maze::Point = backtrack_point(maze, &walk.walk);
+        let half: &'static maze::Point = backtrack_half_step(maze, &walk.walk);
+        let half_step = maze::Point {
+            row: walk.walk.row + half.row,
+            col: walk.walk.col + half.col,
+        };
+        let next = maze::Point {
+            row: walk.walk.row + dir.row,
+            col: walk.walk.col + dir.col,
+        };
+        maze[half_step.row as usize][half_step.col as usize] &= !build::MARKERS_MASK;
+        maze[walk.walk.row as usize][walk.walk.col as usize] &= !build::MARKERS_MASK;
+        build::flush_mini_backtracker_coordinate(maze, half_step);
+        thread::sleep(time::Duration::from_micros(speed));
+        build::flush_mini_backtracker_coordinate(maze, walk.walk);
         thread::sleep(time::Duration::from_micros(speed));
         walk.walk = next;
     }
@@ -281,6 +397,38 @@ fn connect_walk_animated(maze: &mut maze::Maze, mut walk: maze::Point, speed: bu
     build::build_wall_line_animated(maze, walk, speed);
 }
 
+fn connect_mini_walk_animated(
+    maze: &mut maze::Maze,
+    mut walk: maze::Point,
+    speed: build::SpeedUnit,
+) {
+    while (maze[walk.row as usize][walk.col as usize] & build::MARKERS_MASK) != 0 {
+        let dir: &'static maze::Point = backtrack_point(maze, &walk);
+        let half: &'static maze::Point = backtrack_half_step(maze, &walk);
+        let half_step = maze::Point {
+            row: walk.row + half.row,
+            col: walk.col + half.col,
+        };
+        let next = maze::Point {
+            row: walk.row + dir.row,
+            col: walk.col + dir.col,
+        };
+        build_with_mini_marks_animated(maze, walk, next, speed);
+        maze[half_step.row as usize][half_step.col as usize] &= !build::MARKERS_MASK;
+        maze[walk.row as usize][walk.col as usize] &= !build::MARKERS_MASK;
+        build::flush_mini_backtracker_coordinate(maze, half_step);
+        thread::sleep(time::Duration::from_micros(speed));
+        build::flush_mini_backtracker_coordinate(maze, walk);
+        thread::sleep(time::Duration::from_micros(speed));
+        walk = next;
+    }
+    maze[walk.row as usize][walk.col as usize] &= !build::MARKERS_MASK;
+    maze[walk.row as usize][walk.col as usize] &= !WALK_BIT;
+    build::flush_mini_backtracker_coordinate(maze, walk);
+    thread::sleep(time::Duration::from_micros(speed));
+    build::build_mini_wall_line_animated(maze, walk, speed);
+}
+
 fn build_with_marks(maze: &mut maze::Maze, cur: maze::Point, next: maze::Point) {
     let mut wall = cur;
     if next.row < cur.row {
@@ -328,6 +476,35 @@ fn build_with_marks_animated(
     build::build_wall_line_animated(maze, cur, speed);
     build::build_wall_line_animated(maze, wall, speed);
     build::build_wall_line_animated(maze, next, speed);
+}
+
+fn build_with_mini_marks_animated(
+    maze: &mut maze::Maze,
+    cur: maze::Point,
+    next: maze::Point,
+    speed: build::SpeedUnit,
+) {
+    let mut wall = cur;
+    if next.row < cur.row {
+        wall.row -= 1;
+    } else if next.row > cur.row {
+        wall.row += 1;
+    } else if next.col < cur.col {
+        wall.col -= 1;
+    } else if next.col > cur.col {
+        wall.col += 1;
+    } else {
+        print::maze_panic!(
+            "Wall break error. Step through wall didn't work: cur {:?}, next {:?}",
+            cur,
+            next
+        );
+    }
+    maze[cur.row as usize][cur.col as usize] &= !WALK_BIT;
+    maze[next.row as usize][next.col as usize] &= !WALK_BIT;
+    build::build_mini_wall_line_animated(maze, cur, speed);
+    build::build_mini_wall_line_animated(maze, wall, speed);
+    build::build_mini_wall_line_animated(maze, next, speed);
 }
 
 fn is_valid_step(maze: &maze::Maze, next: maze::Point, prev: maze::Point) -> bool {

--- a/maze_progs/builders/src/wilson_adder.rs
+++ b/maze_progs/builders/src/wilson_adder.rs
@@ -64,6 +64,10 @@ pub fn generate_maze(maze: &mut maze::Maze) {
 }
 
 pub fn animate_maze(maze: &mut maze::Maze, speed: speed::Speed) {
+    if maze.is_mini() {
+        animate_mini_maze(maze, speed);
+        return;
+    }
     let animation = build::BUILDER_SPEEDS[speed as usize];
     build::build_wall_outline(maze);
     build::flush_grid(maze);
@@ -108,7 +112,7 @@ pub fn animate_maze(maze: &mut maze::Maze, speed: speed::Speed) {
     }
 }
 
-pub fn animate_mini_maze(maze: &mut maze::Maze, speed: speed::Speed) {
+fn animate_mini_maze(maze: &mut maze::Maze, speed: speed::Speed) {
     let animation = build::BUILDER_SPEEDS[speed as usize];
     build::build_wall_outline(maze);
     build::flush_grid(maze);

--- a/maze_progs/builders/src/wilson_carver.rs
+++ b/maze_progs/builders/src/wilson_carver.rs
@@ -67,6 +67,10 @@ pub fn generate_maze(maze: &mut maze::Maze) {
 }
 
 pub fn animate_maze(maze: &mut maze::Maze, speed: speed::Speed) {
+    if maze.is_mini() {
+        animate_mini_maze(maze, speed);
+        return;
+    }
     let animation = build::BUILDER_SPEEDS[speed as usize];
     build::fill_maze_with_walls(maze);
     build::flush_grid(maze);
@@ -116,7 +120,7 @@ pub fn animate_maze(maze: &mut maze::Maze, speed: speed::Speed) {
     }
 }
 
-pub fn animate_mini_maze(maze: &mut maze::Maze, speed: speed::Speed) {
+fn animate_mini_maze(maze: &mut maze::Maze, speed: speed::Speed) {
     let animation = build::BUILDER_SPEEDS[speed as usize];
     build::fill_maze_with_walls(maze);
     build::flush_grid(maze);

--- a/maze_progs/builders/src/wilson_carver.rs
+++ b/maze_progs/builders/src/wilson_carver.rs
@@ -116,6 +116,56 @@ pub fn animate_maze(maze: &mut maze::Maze, speed: speed::Speed) {
     }
 }
 
+pub fn animate_mini_maze(maze: &mut maze::Maze, speed: speed::Speed) {
+    let animation = build::BUILDER_SPEEDS[speed as usize];
+    build::fill_maze_with_walls(maze);
+    build::flush_grid(maze);
+    build::print_overlap_key_animated(maze);
+    let mut rng = thread_rng();
+    let start = maze::Point {
+        row: 2 * (rng.gen_range(2..maze.row_size() - 1) / 2) + 1,
+        col: 2 * (rng.gen_range(2..maze.col_size() - 1) / 2) + 1,
+    };
+    build::build_mini_path_animated(maze, start, animation);
+    build::flush_mini_coordinate(maze, start);
+    maze[start.row as usize][start.col as usize] |= build::BUILDER_BIT;
+    let mut cur = RandomWalk {
+        prev_row_start: 1,
+        prev: maze::Point { row: 0, col: 0 },
+        walk: maze::Point { row: 1, col: 1 },
+        next: maze::Point { row: 0, col: 0 },
+    };
+    maze[cur.walk.row as usize][cur.walk.col as usize] &= !build::MARKERS_MASK;
+    let mut indices: Vec<usize> = (0..build::NUM_DIRECTIONS).collect();
+    'walking: loop {
+        if maze.exit() {
+            return;
+        }
+        maze[cur.walk.row as usize][cur.walk.col as usize] |= WALK_BIT;
+        indices.shuffle(&mut rng);
+        'choosing_step: for &i in indices.iter() {
+            let p = &build::GENERATE_DIRECTIONS[i];
+            cur.next = maze::Point {
+                row: cur.walk.row + p.row,
+                col: cur.walk.col + p.col,
+            };
+            if !is_valid_step(maze, cur.next, cur.prev) {
+                continue 'choosing_step;
+            }
+
+            match complete_mini_walk_animated(maze, cur, animation) {
+                Some(new_walk) => {
+                    cur = new_walk;
+                    continue 'walking;
+                }
+                None => {
+                    return;
+                }
+            }
+        }
+    }
+}
+
 // Private Functions------------------------------------------------------------------------------
 
 fn complete_walk(maze: &mut maze::Maze, mut walk: RandomWalk) -> Option<RandomWalk> {
@@ -203,6 +253,51 @@ fn complete_walk_animated(
     Some(walk)
 }
 
+fn complete_mini_walk_animated(
+    maze: &mut maze::Maze,
+    mut walk: RandomWalk,
+    speed: build::SpeedUnit,
+) -> Option<RandomWalk> {
+    if build::has_builder_bit(maze, walk.next) {
+        build_with_mini_marks_animated(maze, walk.walk, walk.next, speed);
+        connect_mini_walk_animated(maze, walk.walk, speed);
+        match build::choose_point_from_row_start(maze, walk.prev_row_start, build::ParityPoint::Odd)
+        {
+            Some(point) => {
+                walk.prev_row_start = point.row;
+                walk.walk = point;
+                maze[walk.walk.row as usize][walk.walk.col as usize] &= !build::MARKERS_MASK;
+                walk.prev = maze::Point { row: 0, col: 0 };
+                return Some(walk);
+            }
+            None => {
+                return None;
+            }
+        };
+    }
+    if found_loop(maze, walk.next) {
+        erase_mini_loop_animated(
+            maze,
+            Loop {
+                walk: walk.walk,
+                root: walk.next,
+            },
+            speed,
+        );
+        walk.walk = walk.next;
+        let dir: &'static maze::Point = backtrack_point(maze, &walk.walk);
+        walk.prev = maze::Point {
+            row: walk.walk.row + dir.row,
+            col: walk.walk.col + dir.col,
+        };
+        return Some(walk);
+    }
+    build::mark_mini_origin_animated(maze, walk.walk, walk.next, speed);
+    walk.prev = walk.walk;
+    walk.walk = walk.next;
+    Some(walk)
+}
+
 fn erase_loop(maze: &mut maze::Maze, mut walk: Loop) {
     while walk.walk != walk.root {
         maze[walk.walk.row as usize][walk.walk.col as usize] &= !WALK_BIT;
@@ -234,6 +329,29 @@ fn erase_loop_animated(maze: &mut maze::Maze, mut walk: Loop, speed: build::Spee
         build::flush_cursor_maze_coordinate(maze, half_step);
         thread::sleep(time::Duration::from_micros(speed));
         build::flush_cursor_maze_coordinate(maze, walk.walk);
+        thread::sleep(time::Duration::from_micros(speed));
+        walk.walk = next;
+    }
+}
+
+fn erase_mini_loop_animated(maze: &mut maze::Maze, mut walk: Loop, speed: build::SpeedUnit) {
+    while walk.walk != walk.root {
+        maze[walk.walk.row as usize][walk.walk.col as usize] &= !WALK_BIT;
+        let dir: &'static maze::Point = backtrack_point(maze, &walk.walk);
+        let half: &'static maze::Point = backtrack_half_step(maze, &walk.walk);
+        let half_step = maze::Point {
+            row: walk.walk.row + half.row,
+            col: walk.walk.col + half.col,
+        };
+        let next = maze::Point {
+            row: walk.walk.row + dir.row,
+            col: walk.walk.col + dir.col,
+        };
+        maze[half_step.row as usize][half_step.col as usize] &= !build::MARKERS_MASK;
+        maze[walk.walk.row as usize][walk.walk.col as usize] &= !build::MARKERS_MASK;
+        build::flush_mini_backtracker_coordinate(maze, half_step);
+        thread::sleep(time::Duration::from_micros(speed));
+        build::flush_mini_backtracker_coordinate(maze, walk.walk);
         thread::sleep(time::Duration::from_micros(speed));
         walk.walk = next;
     }
@@ -283,6 +401,38 @@ fn connect_walk_animated(maze: &mut maze::Maze, mut walk: maze::Point, speed: bu
     build::carve_path_walls_animated(maze, walk, speed);
 }
 
+fn connect_mini_walk_animated(
+    maze: &mut maze::Maze,
+    mut walk: maze::Point,
+    speed: build::SpeedUnit,
+) {
+    while (maze[walk.row as usize][walk.col as usize] & build::MARKERS_MASK) != 0 {
+        let dir: &'static maze::Point = backtrack_point(maze, &walk);
+        let half: &'static maze::Point = backtrack_half_step(maze, &walk);
+        let half_step = maze::Point {
+            row: walk.row + half.row,
+            col: walk.col + half.col,
+        };
+        let next = maze::Point {
+            row: walk.row + dir.row,
+            col: walk.col + dir.col,
+        };
+        build_with_mini_marks_animated(maze, walk, next, speed);
+        maze[half_step.row as usize][half_step.col as usize] &= !build::MARKERS_MASK;
+        maze[walk.row as usize][walk.col as usize] &= !build::MARKERS_MASK;
+        build::flush_mini_backtracker_coordinate(maze, half_step);
+        thread::sleep(time::Duration::from_micros(speed));
+        build::flush_mini_backtracker_coordinate(maze, walk);
+        thread::sleep(time::Duration::from_micros(speed));
+        walk = next;
+    }
+    maze[walk.row as usize][walk.col as usize] &= !build::MARKERS_MASK;
+    maze[walk.row as usize][walk.col as usize] &= !WALK_BIT;
+    build::flush_mini_backtracker_coordinate(maze, walk);
+    thread::sleep(time::Duration::from_micros(speed));
+    build::carve_mini_walls_animated(maze, walk, speed);
+}
+
 fn build_with_marks(maze: &mut maze::Maze, cur: maze::Point, next: maze::Point) {
     let mut wall = cur;
     if next.row < cur.row {
@@ -330,6 +480,35 @@ fn build_with_marks_animated(
     build::carve_path_walls_animated(maze, cur, speed);
     build::carve_path_walls_animated(maze, wall, speed);
     build::carve_path_walls_animated(maze, next, speed);
+}
+
+fn build_with_mini_marks_animated(
+    maze: &mut maze::Maze,
+    cur: maze::Point,
+    next: maze::Point,
+    speed: build::SpeedUnit,
+) {
+    let mut wall = cur;
+    if next.row < cur.row {
+        wall.row -= 1;
+    } else if next.row > cur.row {
+        wall.row += 1;
+    } else if next.col < cur.col {
+        wall.col -= 1;
+    } else if next.col > cur.col {
+        wall.col += 1;
+    } else {
+        print::maze_panic!(
+            "Wall break error. Step through wall didn't work: cur {:?}, next {:?}",
+            cur,
+            next
+        );
+    }
+    maze[cur.row as usize][cur.col as usize] &= !WALK_BIT;
+    maze[next.row as usize][next.col as usize] &= !WALK_BIT;
+    build::carve_mini_walls_animated(maze, cur, speed);
+    build::carve_mini_walls_animated(maze, wall, speed);
+    build::carve_mini_walls_animated(maze, next, speed);
 }
 
 fn is_valid_step(maze: &maze::Maze, next: maze::Point, prev: maze::Point) -> bool {

--- a/maze_progs/demo/src/main.rs
+++ b/maze_progs/demo/src/main.rs
@@ -33,9 +33,6 @@ fn main() {
         }
         process_current = true;
     }
-    let mut run = tables::MazeRunner::new();
-    run.args.odd_rows = dimensions.0;
-    run.args.odd_cols = dimensions.1;
     let mut rng = thread_rng();
     let modification_probability = Bernoulli::new(0.2);
     let invisible = print::InvisibleCursor::new();
@@ -54,10 +51,16 @@ fn main() {
     })
     .expect("Could not set quit handler.");
     loop {
+        let mut run = tables::MazeRunner::new();
+        run.args.odd_rows = dimensions.0;
+        run.args.odd_cols = dimensions.1;
         print::clear_screen();
         match tables::WALL_STYLES.choose(&mut rng) {
             Some(&(_key, val)) => run.args.style = val,
             None => print::maze_panic!("Styles not set for loop, broken"),
+        }
+        if run.args.style == maze::MazeStyle::Mini {
+            run.args.odd_rows *= 2;
         }
         let mut maze = maze::Maze::new(run.args);
         let build_speed = match tables::SPEEDS.choose(&mut rng) {
@@ -98,7 +101,7 @@ fn main() {
         solve_algo(monitor, solve_speed);
         print::set_cursor_position(
             maze::Point {
-                row: dimensions.0 + 2,
+                row: dimensions.0 + 3,
                 col: 0,
             },
             maze::Offset::default(),

--- a/maze_progs/key/src/lib.rs
+++ b/maze_progs/key/src/lib.rs
@@ -80,7 +80,7 @@ pub static THREAD_COLORS: [ThreadColor; 16] = [
     // 0b0110
     ThreadColor {
         block: BLOCK,
-        ansi: ANSI_CYN,
+        ansi: 152,
     },
     // 0b0111
     ThreadColor {

--- a/maze_progs/maze/src/lib.rs
+++ b/maze_progs/maze/src/lib.rs
@@ -150,6 +150,10 @@ impl Maze {
     pub fn style_index(&self) -> usize {
         self.wall_style_index
     }
+
+    pub fn is_mini(&self) -> bool {
+        self.wall_style_index == (MazeStyle::Mini as usize)
+    }
 }
 
 impl Index<usize> for Maze {

--- a/maze_progs/maze/src/lib.rs
+++ b/maze_progs/maze/src/lib.rs
@@ -60,9 +60,10 @@ pub struct Offset {
     pub add_cols: i32,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Eq, PartialEq)]
 pub enum MazeStyle {
-    Sharp = 0,
+    Mini = 0,
+    Sharp,
     Round,
     Doubles,
     Bold,
@@ -118,7 +119,11 @@ impl Maze {
             maze_row_size: (rows),
             maze_col_size: (cols),
             offset: args.offset,
-            wall_style_index: (args.style as usize),
+            wall_style_index: if args.style != MazeStyle::Mini {
+                (args.style as usize) + 1
+            } else {
+                0
+            },
             receiver: Some(rec),
         }
     }
@@ -142,7 +147,7 @@ impl Maze {
         self.maze_col_size
     }
 
-    pub fn wall_style(&self) -> &[&'static str] {
+    pub fn wall_style(&self) -> &[char] {
         &WALL_STYLES
             [(self.wall_style_index * WALL_ROW)..(self.wall_style_index * WALL_ROW + WALL_ROW)]
     }
@@ -178,6 +183,10 @@ impl Default for MazeArgs {
     }
 }
 
+pub fn mini_row(row_parity: usize) -> &'static [char] {
+    &WALL_STYLES[row_parity * WALL_ROW..row_parity * WALL_ROW + WALL_ROW]
+}
+
 // Read Only Data Available to Any Maze Users
 
 // Any modification made to these bits by a builder MUST be cleared before build process completes.
@@ -195,23 +204,30 @@ pub const WEST_WALL: WallLine = 0b1000;
 // Walls are constructed in terms of other walls they need to connect to. For example, read
 // 0b0011 as, "this is a wall square that must connect to other walls to the East and North."
 const WALL_ROW: usize = 16;
-pub static WALL_STYLES: [&str; 112] = [
+pub static WALL_STYLES: [char; 144] = [
     // 0bWestSouthEastNorth. Note: 0b0000 is a floating wall with no walls around.
     // Then, count from 0 (0b0000) to 15 (0b1111) in binary to form different wall shapes.
+    // Mini rows are special but users don't have to worry about why.--------------
+    // Even Mini Row.
+    //0   1    2   3     4    5    6    7    8    9    10   11   12   13   14  15
+    '▔', '▀', '▀', '▀', '█', '█', '█', '█', '▀', '▀', '▀', '▀', '█', '█', '█', '█',
+    // Odd Mini Row
+    '▁', '█', '▄', '█', '▄', '█', '▄', '█', '▄', '█', '▄', '█', '▄', '█', '▄', '█',
+    //-----------------------------------------------------------------------------
     // sharp
-    "■", "╵", "╶", "└", "╷", "│", "┌", "├", "╴", "┘", "─", "┴", "┐", "┤", "┬", "┼",
+    '■', '╵', '╶', '└', '╷', '│', '┌', '├', '╴', '┘', '─', '┴', '┐', '┤', '┬', '┼',
     // rounded
-    "●", "╵", "╶", "╰", "╷", "│", "╭", "├", "╴", "╯", "─", "┴", "╮", "┤", "┬", "┼",
+    '●', '╵', '╶', '╰', '╷', '│', '╭', '├', '╴', '╯', '─', '┴', '╮', '┤', '┬', '┼',
     // doubles
-    "◫", "║", "═", "╚", "║", "║", "╔", "╠", "═", "╝", "═", "╩", "╗", "╣", "╦", "╬",
+    '◫', '║', '═', '╚', '║', '║', '╔', '╠', '═', '╝', '═', '╩', '╗', '╣', '╦', '╬',
     // bold
-    "■", "╹", "╺", "┗", "╻", "┃", "┏", "┣", "╸", "┛", "━", "┻", "┓", "┫", "┳", "╋",
+    '■', '╹', '╺', '┗', '╻', '┃', '┏', '┣', '╸', '┛', '━', '┻', '┓', '┫', '┳', '╋',
     // contrast
-    "█", "█", "█", "█", "█", "█", "█", "█", "█", "█", "█", "█", "█", "█", "█", "█",
+    '█', '█', '█', '█', '█', '█', '█', '█', '█', '█', '█', '█', '█', '█', '█', '█',
     // half
-    "▄", "█", "▄", "█", "▄", "█", "▄", "█", "▄", "█", "▄", "█", "▄", "█", "▄", "█",
+    '▄', '█', '▄', '█', '▄', '█', '▄', '█', '▄', '█', '▄', '█', '▄', '█', '▄', '█',
     // spikes
-    "✸", "╀", "┾", "╊", "╁", "╂", "╆", "╊", "┽", "╃", "┿", "╇", "╅", "╉", "╈", "╋",
+    '✸', '╀', '┾', '╊', '╁', '╂', '╆', '╊', '┽', '╃', '┿', '╇', '╅', '╉', '╈', '╋',
 ];
 
 // north, east, south, west provided to any users of a maze for convenience.

--- a/maze_progs/maze/src/lib.rs
+++ b/maze_progs/maze/src/lib.rs
@@ -178,10 +178,6 @@ impl Default for MazeArgs {
     }
 }
 
-pub fn mini_row(row_parity: usize) -> &'static [char] {
-    &WALL_STYLES[row_parity * WALL_ROW..row_parity * WALL_ROW + WALL_ROW]
-}
-
 // Read Only Data Available to Any Maze Users
 
 // Any modification made to these bits by a builder MUST be cleared before build process completes.

--- a/maze_progs/maze/src/lib.rs
+++ b/maze_progs/maze/src/lib.rs
@@ -106,7 +106,7 @@ impl Maze {
             maze_row_size: (rows),
             maze_col_size: (cols),
             offset: args.offset,
-            wall_style_index: (args.style as usize),
+            wall_style_index: args.style as usize,
             receiver: None,
         }
     }
@@ -119,11 +119,7 @@ impl Maze {
             maze_row_size: (rows),
             maze_col_size: (cols),
             offset: args.offset,
-            wall_style_index: if args.style != MazeStyle::Mini {
-                (args.style as usize) + 1
-            } else {
-                0
-            },
+            wall_style_index: args.style as usize,
             receiver: Some(rec),
         }
     }
@@ -147,9 +143,8 @@ impl Maze {
         self.maze_col_size
     }
 
-    pub fn wall_style(&self) -> &[char] {
-        &WALL_STYLES
-            [(self.wall_style_index * WALL_ROW)..(self.wall_style_index * WALL_ROW + WALL_ROW)]
+    pub fn wall_char(&self, wall_mask_index: usize) -> char {
+        WALL_STYLES[(self.wall_style_index * WALL_ROW) + wall_mask_index]
     }
 
     pub fn style_index(&self) -> usize {
@@ -204,16 +199,11 @@ pub const WEST_WALL: WallLine = 0b1000;
 // Walls are constructed in terms of other walls they need to connect to. For example, read
 // 0b0011 as, "this is a wall square that must connect to other walls to the East and North."
 const WALL_ROW: usize = 16;
-pub static WALL_STYLES: [char; 144] = [
+pub static WALL_STYLES: [char; 128] = [
     // 0bWestSouthEastNorth. Note: 0b0000 is a floating wall with no walls around.
     // Then, count from 0 (0b0000) to 15 (0b1111) in binary to form different wall shapes.
-    // Mini rows are special but users don't have to worry about why.--------------
-    // Even Mini Row.
-    //0   1    2   3     4    5    6    7    8    9    10   11   12   13   14  15
+    // mini
     '▔', '▀', '▀', '▀', '█', '█', '█', '█', '▀', '▀', '▀', '▀', '█', '█', '█', '█',
-    // Odd Mini Row
-    '▁', '█', '▄', '█', '▄', '█', '▄', '█', '▄', '█', '▄', '█', '▄', '█', '▄', '█',
-    //-----------------------------------------------------------------------------
     // sharp
     '■', '╵', '╶', '└', '╷', '│', '┌', '├', '╴', '┘', '─', '┴', '┐', '┤', '┬', '┼',
     // rounded

--- a/maze_progs/painters/src/distance.rs
+++ b/maze_progs/painters/src/distance.rs
@@ -1,10 +1,8 @@
 use crate::rgb;
 use builders::build::print_square;
-use crossterm::{execute, style::Print};
 use maze;
 use solvers::solve;
 use std::collections::{HashSet, VecDeque};
-use std::io::{self};
 
 use std::{thread, time};
 
@@ -45,10 +43,6 @@ pub fn paint_distance_from_center(monitor: solve::SolverMonitor) {
         }
     }
     painter(&mut lk.maze, &map);
-    match execute!(io::stdout(), Print('\n')) {
-        Ok(_) => {}
-        Err(_) => print::maze_panic!("Painter failed to print."),
-    }
 }
 
 pub fn animate_distance_from_center(monitor: solve::SolverMonitor, speed: speed::Speed) {
@@ -110,22 +104,76 @@ pub fn animate_distance_from_center(monitor: solve::SolverMonitor, speed: speed:
     for h in handles {
         h.join().expect("Error joining a thread.");
     }
-    match monitor.lock() {
-        Ok(lk) => {
-            print::set_cursor_position(
-                maze::Point {
-                    row: lk.maze.row_size(),
-                    col: lk.maze.col_size(),
-                },
-                lk.maze.offset(),
-            );
-            match execute!(io::stdout(), Print('\n')) {
-                Ok(_) => {}
-                Err(_) => print::maze_panic!("Painter failed to print."),
+}
+
+pub fn animate_mini_distance_from_center(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    let start = if let Ok(mut lk) = monitor.lock() {
+        let row_mid = lk.maze.row_size() / 2;
+        let col_mid = lk.maze.col_size() / 2;
+        let start = maze::Point {
+            row: row_mid + 1 - (row_mid % 2),
+            col: col_mid + 1 - (col_mid % 2),
+        };
+        lk.map.distances.insert(start, 0);
+        let mut bfs = VecDeque::from([(start, 0u64)]);
+        lk.maze[start.row as usize][start.col as usize] |= rgb::MEASURE;
+        while let Some(cur) = bfs.pop_front() {
+            if lk.maze.exit() {
+                return;
+            }
+            if cur.1 > lk.map.max {
+                lk.map.max = cur.1;
+            }
+            for &p in maze::CARDINAL_DIRECTIONS.iter() {
+                let next = maze::Point {
+                    row: cur.0.row + p.row,
+                    col: cur.0.col + p.col,
+                };
+                if (lk.maze[next.row as usize][next.col as usize] & maze::PATH_BIT) == 0
+                    || (lk.maze[next.row as usize][next.col as usize] & rgb::MEASURE) != 0
+                {
+                    continue;
+                }
+                lk.maze[next.row as usize][next.col as usize] |= rgb::MEASURE;
+                lk.map.distances.insert(next, cur.1 + 1);
+                bfs.push_back((next, cur.1 + 1));
             }
         }
-        Err(p) => print::maze_panic!("Thread panicked: {}", p),
+        start
+    } else {
+        print::maze_panic!("Thread panic.");
     };
+
+    let mut rng = thread_rng();
+    let rand_color_choice: usize = rng.gen_range(0..3);
+    let mut handles = Vec::with_capacity(rgb::NUM_PAINTERS);
+    let animation = rgb::ANIMATION_SPEEDS[speed as usize];
+    for painter in 0..rgb::NUM_PAINTERS - 1 {
+        let monitor_clone = monitor.clone();
+        handles.push(thread::spawn(move || {
+            painter_mini_animated(
+                monitor_clone,
+                rgb::ThreadGuide {
+                    bias: painter,
+                    color_i: rand_color_choice,
+                    p: start,
+                },
+                animation,
+            );
+        }));
+    }
+    painter_mini_animated(
+        monitor.clone(),
+        rgb::ThreadGuide {
+            bias: rgb::NUM_PAINTERS - 1,
+            color_i: rand_color_choice,
+            p: start,
+        },
+        animation,
+    );
+    for h in handles {
+        h.join().expect("Error joining a thread.");
+    }
 }
 
 // Private Helper Functions-----------------------------------------------------------------------
@@ -133,25 +181,59 @@ pub fn animate_distance_from_center(monitor: solve::SolverMonitor, speed: speed:
 fn painter(maze: &maze::Maze, map: &solve::MaxMap) {
     let mut rng = thread_rng();
     let rand_color_choice: usize = rng.gen_range(0..3);
-    for r in 0..maze.row_size() {
-        for c in 0..maze.col_size() {
-            let cur = maze::Point { row: r, col: c };
-            match map.distances.get(&cur) {
-                Some(dist) => {
-                    let intensity = (map.max - dist) as f64 / map.max as f64;
+    if maze.style_index() == (maze::MazeStyle::Mini as usize) {
+        for r in 0..maze.row_size() {
+            for c in 0..maze.col_size() {
+                let cur = maze::Point { row: r, col: c };
+                if (maze[r as usize][c as usize] & maze::PATH_BIT) == 0 {
+                    solve::print_mini_point(maze, cur);
+                    continue;
+                }
+                let dist = map.distances.get(&cur).expect("Could not find map entry?");
+                let intensity = (map.max - dist) as f64 / map.max as f64;
+                let dark = (255f64 * intensity) as u8;
+                let bright = 128 + (127f64 * intensity) as u8;
+                let mut channels: rgb::Rgb = [dark, dark, dark];
+                channels[rand_color_choice] = bright;
+                if (maze[(cur.row + 1) as usize][cur.col as usize] & maze::PATH_BIT) != 0 {
+                    let neighbor = maze::Point {
+                        row: cur.row + 1,
+                        col: cur.col,
+                    };
+                    let neighbor_dist = map.distances.get(&neighbor).expect("Empty map");
+                    let intensity = (map.max - neighbor_dist) as f64 / map.max as f64;
                     let dark = (255f64 * intensity) as u8;
                     let bright = 128 + (127f64 * intensity) as u8;
-                    let mut channels: rgb::Rgb = [dark, dark, dark];
-                    channels[rand_color_choice] = bright;
-                    rgb::print_rgb(channels, cur, maze.offset());
+                    let mut neighbor_channels: rgb::Rgb = [dark, dark, dark];
+                    neighbor_channels[rand_color_choice] = bright;
+                    rgb::print_mini_rgb(
+                        Some(channels),
+                        Some(neighbor_channels),
+                        cur,
+                        maze.offset(),
+                    );
+                } else {
+                    rgb::print_mini_rgb(Some(channels), None, cur, maze.offset());
                 }
-                None => print_square(&maze, cur),
             }
         }
-    }
-    match execute!(io::stdout(), Print('\n')) {
-        Ok(_) => {}
-        Err(_) => print::maze_panic!("Painter failed to print."),
+    } else {
+        for r in 0..maze.row_size() {
+            for c in 0..maze.col_size() {
+                let cur = maze::Point { row: r, col: c };
+                match map.distances.get(&cur) {
+                    Some(dist) => {
+                        let intensity = (map.max - dist) as f64 / map.max as f64;
+                        let dark = (255f64 * intensity) as u8;
+                        let bright = 128 + (127f64 * intensity) as u8;
+                        let mut channels: rgb::Rgb = [dark, dark, dark];
+                        channels[rand_color_choice] = bright;
+                        rgb::print_rgb(channels, cur, maze.offset());
+                    }
+                    None => print_square(&maze, cur),
+                }
+            }
+        }
     }
 }
 
@@ -186,6 +268,106 @@ fn painter_animated(
             }
             Err(p) => print::maze_panic!("Thread panicked with lock: {}", p),
         };
+        thread::sleep(time::Duration::from_micros(animation));
+        let mut i = guide.bias;
+        while {
+            let p = &maze::CARDINAL_DIRECTIONS[i];
+            let next = maze::Point {
+                row: cur.row + p.row,
+                col: cur.col + p.col,
+            };
+            if match monitor.lock() {
+                Err(p) => print::maze_panic!("Panic with lock: {}", p),
+                Ok(lk) => (lk.maze[next.row as usize][next.col as usize] & maze::PATH_BIT) != 0,
+            } && !seen.contains(&next)
+            {
+                seen.insert(next);
+                bfs.push_back(next);
+            }
+            i = (i + 1) % rgb::NUM_PAINTERS;
+            i != guide.bias
+        } {}
+    }
+}
+
+fn painter_mini_animated(
+    monitor: solve::SolverMonitor,
+    guide: rgb::ThreadGuide,
+    animation: rgb::SpeedUnit,
+) {
+    let mut seen = HashSet::from([guide.p]);
+    let mut bfs = VecDeque::from([guide.p]);
+    while let Some(cur) = bfs.pop_front() {
+        match monitor.lock() {
+            Ok(mut lk) => {
+                if lk.maze.exit() || lk.count == lk.map.distances.len() {
+                    return;
+                }
+                if (lk.maze[cur.row as usize][cur.col as usize] & rgb::PAINT) == 0 {
+                    let dist = lk
+                        .map
+                        .distances
+                        .get(&cur)
+                        .expect("Could not find map entry?");
+                    let intensity = (lk.map.max - dist) as f64 / lk.map.max as f64;
+                    let dark = (255f64 * intensity) as u8;
+                    let bright = 128 + (127f64 * intensity) as u8;
+                    let mut channels: rgb::Rgb = [dark, dark, dark];
+                    channels[guide.color_i] = bright;
+                    lk.maze[cur.row as usize][cur.col as usize] |= rgb::PAINT;
+                    lk.count += 1;
+                    if cur.row % 2 == 0 {
+                        if (lk.maze[(cur.row + 1) as usize][cur.col as usize] & maze::PATH_BIT) != 0
+                        {
+                            let neighbor = maze::Point {
+                                row: cur.row + 1,
+                                col: cur.col,
+                            };
+                            lk.maze[neighbor.row as usize][neighbor.col as usize] |= rgb::PAINT;
+                            let neighbor_dist = lk.map.distances.get(&neighbor).expect("Empty map");
+                            let intensity = (lk.map.max - neighbor_dist) as f64 / lk.map.max as f64;
+                            let dark = (255f64 * intensity) as u8;
+                            let bright = 128 + (127f64 * intensity) as u8;
+                            let mut neighbor_channels: rgb::Rgb = [dark, dark, dark];
+                            neighbor_channels[guide.color_i] = bright;
+                            rgb::animate_mini_rgb(
+                                Some(channels),
+                                Some(neighbor_channels),
+                                cur,
+                                lk.maze.offset(),
+                            );
+                        } else {
+                            rgb::animate_mini_rgb(Some(channels), None, cur, lk.maze.offset());
+                        }
+                    } else {
+                        if (lk.maze[(cur.row - 1) as usize][cur.col as usize] & maze::PATH_BIT) != 0
+                        {
+                            let neighbor = maze::Point {
+                                row: cur.row - 1,
+                                col: cur.col,
+                            };
+                            lk.maze[neighbor.row as usize][neighbor.col as usize] |= rgb::PAINT;
+                            let neighbor_dist = lk.map.distances.get(&neighbor).expect("Empty map");
+                            let intensity = (lk.map.max - neighbor_dist) as f64 / lk.map.max as f64;
+                            let dark = (255f64 * intensity) as u8;
+                            let bright = 128 + (127f64 * intensity) as u8;
+                            let mut neighbor_channels: rgb::Rgb = [dark, dark, dark];
+                            neighbor_channels[guide.color_i] = bright;
+                            rgb::animate_mini_rgb(
+                                Some(neighbor_channels),
+                                Some(channels),
+                                cur,
+                                lk.maze.offset(),
+                            );
+                        } else {
+                            rgb::animate_mini_rgb(None, Some(channels), cur, lk.maze.offset());
+                        }
+                    }
+                }
+            }
+            Err(p) => print::maze_panic!("Thread panicked with lock: {}", p),
+        }
+
         thread::sleep(time::Duration::from_micros(animation));
         let mut i = guide.bias;
         while {

--- a/maze_progs/painters/src/distance.rs
+++ b/maze_progs/painters/src/distance.rs
@@ -46,6 +46,15 @@ pub fn paint_distance_from_center(monitor: solve::SolverMonitor) {
 }
 
 pub fn animate_distance_from_center(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    if monitor
+        .lock()
+        .unwrap_or_else(|_| print::maze_panic!("Thread panicked"))
+        .maze
+        .is_mini()
+    {
+        animate_mini_distance_from_center(monitor, speed);
+        return;
+    }
     let start = if let Ok(mut lk) = monitor.lock() {
         let row_mid = lk.maze.row_size() / 2;
         let col_mid = lk.maze.col_size() / 2;
@@ -106,7 +115,7 @@ pub fn animate_distance_from_center(monitor: solve::SolverMonitor, speed: speed:
     }
 }
 
-pub fn animate_mini_distance_from_center(monitor: solve::SolverMonitor, speed: speed::Speed) {
+fn animate_mini_distance_from_center(monitor: solve::SolverMonitor, speed: speed::Speed) {
     let start = if let Ok(mut lk) = monitor.lock() {
         let row_mid = lk.maze.row_size() / 2;
         let col_mid = lk.maze.col_size() / 2;

--- a/maze_progs/painters/src/rgb.rs
+++ b/maze_progs/painters/src/rgb.rs
@@ -1,6 +1,6 @@
 use crossterm::{
     execute, queue,
-    style::{Color, Print, ResetColor, SetForegroundColor},
+    style::{Color, Print, ResetColor, SetBackgroundColor, SetForegroundColor},
 };
 use print::maze_panic;
 use std::io::{self};
@@ -55,5 +55,129 @@ pub fn animate_rgb(rgb: Rgb, p: maze::Point, offset: maze::Offset) {
     ) {
         Ok(_) => {}
         Err(_) => maze_panic!("Could not print rgb."),
+    }
+}
+
+pub fn animate_mini_rgb(
+    rgb_top: Option<Rgb>,
+    rgb_bottom: Option<Rgb>,
+    p: maze::Point,
+    offset: maze::Offset,
+) {
+    print::set_cursor_position(
+        maze::Point {
+            row: p.row / 2,
+            col: p.col,
+        },
+        offset,
+    );
+    match (rgb_top, rgb_bottom) {
+        (Some(path_above), Some(path_below)) => {
+            execute!(
+                io::stdout(),
+                SetForegroundColor(Color::Rgb {
+                    r: path_above[R],
+                    g: path_above[G],
+                    b: path_above[B]
+                }),
+                SetBackgroundColor(Color::Rgb {
+                    r: path_below[R],
+                    g: path_below[G],
+                    b: path_below[B]
+                }),
+                Print('▀'),
+                ResetColor,
+            )
+            .expect("Printer broke.");
+        }
+        (Some(path_with_wall_below), None) => {
+            execute!(
+                io::stdout(),
+                SetBackgroundColor(Color::Rgb {
+                    r: path_with_wall_below[R],
+                    g: path_with_wall_below[G],
+                    b: path_with_wall_below[B]
+                }),
+                Print('▄'),
+                ResetColor,
+            )
+            .expect("Printer broke.");
+        }
+        (None, Some(path_with_wall_above)) => {
+            execute!(
+                io::stdout(),
+                SetBackgroundColor(Color::Rgb {
+                    r: path_with_wall_above[R],
+                    g: path_with_wall_above[G],
+                    b: path_with_wall_above[B]
+                }),
+                Print('▀'),
+                ResetColor,
+            )
+            .expect("Printer broke.");
+        }
+        _ => {}
+    }
+}
+
+pub fn print_mini_rgb(
+    rgb_top: Option<Rgb>,
+    rgb_bottom: Option<Rgb>,
+    p: maze::Point,
+    offset: maze::Offset,
+) {
+    print::set_cursor_position(
+        maze::Point {
+            row: p.row / 2,
+            col: p.col,
+        },
+        offset,
+    );
+    match (rgb_top, rgb_bottom) {
+        (Some(path_above), Some(path_below)) => {
+            queue!(
+                io::stdout(),
+                SetForegroundColor(Color::Rgb {
+                    r: path_above[R],
+                    g: path_above[G],
+                    b: path_above[B]
+                }),
+                SetBackgroundColor(Color::Rgb {
+                    r: path_below[R],
+                    g: path_below[G],
+                    b: path_below[B]
+                }),
+                Print('▀'),
+                ResetColor,
+            )
+            .expect("Printer broke.");
+        }
+        (Some(path_with_wall_below), None) => {
+            queue!(
+                io::stdout(),
+                SetBackgroundColor(Color::Rgb {
+                    r: path_with_wall_below[R],
+                    g: path_with_wall_below[G],
+                    b: path_with_wall_below[B]
+                }),
+                Print('▄'),
+                ResetColor,
+            )
+            .expect("Printer broke.");
+        }
+        (None, Some(path_with_wall_above)) => {
+            queue!(
+                io::stdout(),
+                SetBackgroundColor(Color::Rgb {
+                    r: path_with_wall_above[R],
+                    g: path_with_wall_above[G],
+                    b: path_with_wall_above[B]
+                }),
+                Print('▀'),
+                ResetColor,
+            )
+            .expect("Printer broke.");
+        }
+        _ => {}
     }
 }

--- a/maze_progs/painters/src/runs.rs
+++ b/maze_progs/painters/src/runs.rs
@@ -66,6 +66,15 @@ pub fn paint_run_lengths(monitor: solve::SolverMonitor) {
 }
 
 pub fn animate_run_lengths(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    if monitor
+        .lock()
+        .unwrap_or_else(|_| print::maze_panic!("Thread panicked"))
+        .maze
+        .is_mini()
+    {
+        animate_mini_run_lengths(monitor, speed);
+        return;
+    }
     let start: maze::Point = if let Ok(mut lk) = monitor.lock() {
         let row_mid = lk.maze.row_size() / 2;
         let col_mid = lk.maze.col_size() / 2;
@@ -149,7 +158,7 @@ pub fn animate_run_lengths(monitor: solve::SolverMonitor, speed: speed::Speed) {
     }
 }
 
-pub fn animate_mini_run_lengths(monitor: solve::SolverMonitor, speed: speed::Speed) {
+fn animate_mini_run_lengths(monitor: solve::SolverMonitor, speed: speed::Speed) {
     let start: maze::Point = if let Ok(mut lk) = monitor.lock() {
         let row_mid = lk.maze.row_size() / 2;
         let col_mid = lk.maze.col_size() / 2;

--- a/maze_progs/painters/src/runs.rs
+++ b/maze_progs/painters/src/runs.rs
@@ -1,10 +1,8 @@
 use crate::rgb;
 use builders::build::print_square;
-use crossterm::{execute, style::Print};
 use maze;
 use solvers::solve;
 use speed;
-use std::io::{self};
 
 use std::collections::{HashSet, VecDeque};
 use std::{thread, time};
@@ -65,10 +63,6 @@ pub fn paint_run_lengths(monitor: solve::SolverMonitor) {
         }
     }
     painter(&mut lk.maze, &map);
-    match execute!(io::stdout(), Print('\n')) {
-        Ok(_) => {}
-        Err(_) => print::maze_panic!("Painter failed to print."),
-    }
 }
 
 pub fn animate_run_lengths(monitor: solve::SolverMonitor, speed: speed::Speed) {
@@ -127,7 +121,7 @@ pub fn animate_run_lengths(monitor: solve::SolverMonitor, speed: speed::Speed) {
     let rand_color_choice: usize = rng.gen_range(0..3);
     let mut handles = Vec::with_capacity(rgb::NUM_PAINTERS);
     let animation = rgb::ANIMATION_SPEEDS[speed as usize];
-    for painter in 0..rgb::NUM_PAINTERS {
+    for painter in 0..rgb::NUM_PAINTERS - 1 {
         let monitor_clone = monitor.clone();
         handles.push(thread::spawn(move || {
             painter_animated(
@@ -141,25 +135,102 @@ pub fn animate_run_lengths(monitor: solve::SolverMonitor, speed: speed::Speed) {
             );
         }));
     }
+    painter_animated(
+        monitor.clone(),
+        rgb::ThreadGuide {
+            bias: rgb::NUM_PAINTERS - 1,
+            color_i: rand_color_choice,
+            p: start,
+        },
+        animation,
+    );
     for h in handles {
         h.join().expect("Error joining a thread.");
     }
-    match monitor.lock() {
-        Ok(lk) => {
-            print::set_cursor_position(
-                maze::Point {
-                    row: lk.maze.row_size(),
-                    col: lk.maze.col_size(),
-                },
-                lk.maze.offset(),
-            );
-            match execute!(io::stdout(), Print('\n')) {
-                Ok(_) => {}
-                Err(_) => print::maze_panic!("Painter failed to print."),
+}
+
+pub fn animate_mini_run_lengths(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    let start: maze::Point = if let Ok(mut lk) = monitor.lock() {
+        let row_mid = lk.maze.row_size() / 2;
+        let col_mid = lk.maze.col_size() / 2;
+        let start = maze::Point {
+            row: row_mid + 1 - (row_mid % 2),
+            col: col_mid + 1 - (col_mid % 2),
+        };
+        lk.map.distances.insert(start, 0);
+        let mut bfs = VecDeque::from([RunPoint {
+            len: 0,
+            prev: start,
+            cur: start,
+        }]);
+        lk.maze[start.row as usize][start.col as usize] |= rgb::MEASURE;
+        while let Some(cur) = bfs.pop_front() {
+            if lk.maze.exit() {
+                return;
+            }
+            if cur.len > lk.map.max {
+                lk.map.max = cur.len;
+            }
+            for &p in maze::CARDINAL_DIRECTIONS.iter() {
+                let next = maze::Point {
+                    row: cur.cur.row + p.row,
+                    col: cur.cur.col + p.col,
+                };
+                if (lk.maze[next.row as usize][next.col as usize] & maze::PATH_BIT) == 0
+                    || (lk.maze[next.row as usize][next.col as usize] & rgb::MEASURE) != 0
+                {
+                    continue;
+                }
+                let next_run_len =
+                    if (next.row).abs_diff(cur.prev.row) == (next.col).abs_diff(cur.prev.col) {
+                        1
+                    } else {
+                        cur.len + 1
+                    };
+                lk.maze[next.row as usize][next.col as usize] |= rgb::MEASURE;
+                lk.map.distances.insert(next, next_run_len);
+                bfs.push_back(RunPoint {
+                    len: next_run_len,
+                    prev: cur.cur,
+                    cur: next,
+                });
             }
         }
-        Err(p) => print::maze_panic!("Thread panicked: {}", p),
+        start
+    } else {
+        print::maze_panic!("Thread panic.");
     };
+
+    let mut rng = thread_rng();
+    let rand_color_choice: usize = rng.gen_range(0..3);
+    let mut handles = Vec::with_capacity(rgb::NUM_PAINTERS);
+    let animation = rgb::ANIMATION_SPEEDS[speed as usize];
+    for painter in 0..rgb::NUM_PAINTERS - 1 {
+        let monitor_clone = monitor.clone();
+        handles.push(thread::spawn(move || {
+            painter_mini_animated(
+                monitor_clone,
+                rgb::ThreadGuide {
+                    bias: painter,
+                    color_i: rand_color_choice,
+                    p: start,
+                },
+                animation,
+            );
+        }));
+    }
+    painter_mini_animated(
+        monitor.clone(),
+        rgb::ThreadGuide {
+            bias: rgb::NUM_PAINTERS - 1,
+            color_i: rand_color_choice,
+            p: start,
+        },
+        animation,
+    );
+    for h in handles {
+        h.join().expect("Error joining a thread.");
+    }
 }
 
 // Private Helper Functions-----------------------------------------------------------------------
@@ -167,27 +238,59 @@ pub fn animate_run_lengths(monitor: solve::SolverMonitor, speed: speed::Speed) {
 fn painter(maze: &maze::Maze, map: &solve::MaxMap) {
     let mut rng = thread_rng();
     let rand_color_choice: usize = rng.gen_range(0..3);
-    for r in 0..maze.row_size() {
-        for c in 0..maze.col_size() {
-            let cur = maze::Point { row: r, col: c };
-            match map.distances.get(&cur) {
-                Some(run) => {
-                    let intensity = (map.max - run) as f64 / map.max as f64;
+    if maze.style_index() == (maze::MazeStyle::Mini as usize) {
+        for r in 0..maze.row_size() {
+            for c in 0..maze.col_size() {
+                let cur = maze::Point { row: r, col: c };
+                if (maze[r as usize][c as usize] & maze::PATH_BIT) == 0 {
+                    solve::print_mini_point(maze, cur);
+                    continue;
+                }
+                let dist = map.distances.get(&cur).expect("Could not find map entry?");
+                let intensity = (map.max - dist) as f64 / map.max as f64;
+                let dark = (255f64 * intensity) as u8;
+                let bright = 128 + (127f64 * intensity) as u8;
+                let mut channels: rgb::Rgb = [dark, dark, dark];
+                channels[rand_color_choice] = bright;
+                if (maze[(cur.row + 1) as usize][cur.col as usize] & maze::PATH_BIT) != 0 {
+                    let neighbor = maze::Point {
+                        row: cur.row + 1,
+                        col: cur.col,
+                    };
+                    let neighbor_dist = map.distances.get(&neighbor).expect("Empty map");
+                    let intensity = (map.max - neighbor_dist) as f64 / map.max as f64;
                     let dark = (255f64 * intensity) as u8;
                     let bright = 128 + (127f64 * intensity) as u8;
-                    let mut channels: rgb::Rgb = [dark, dark, dark];
-                    channels[rand_color_choice] = bright;
-                    rgb::print_rgb(channels, cur, maze.offset());
+                    let mut neighbor_channels: rgb::Rgb = [dark, dark, dark];
+                    neighbor_channels[rand_color_choice] = bright;
+                    rgb::print_mini_rgb(
+                        Some(channels),
+                        Some(neighbor_channels),
+                        cur,
+                        maze.offset(),
+                    );
+                } else {
+                    rgb::print_mini_rgb(Some(channels), None, cur, maze.offset());
                 }
-                None => {
-                    print_square(&maze, cur);
-                }
-            };
+            }
         }
-    }
-    match execute!(io::stdout(), Print('\n')) {
-        Ok(_) => {}
-        Err(_) => print::maze_panic!("Painter failed to print."),
+    } else {
+        for r in 0..maze.row_size() {
+            for c in 0..maze.col_size() {
+                let cur = maze::Point { row: r, col: c };
+                match map.distances.get(&cur) {
+                    Some(dist) => {
+                        let intensity = (map.max - dist) as f64 / map.max as f64;
+                        let dark = (255f64 * intensity) as u8;
+                        let bright = 128 + (127f64 * intensity) as u8;
+                        let mut channels: rgb::Rgb = [dark, dark, dark];
+                        channels[rand_color_choice] = bright;
+                        rgb::print_rgb(channels, cur, maze.offset());
+                    }
+                    None => print_square(&maze, cur),
+                }
+            }
+        }
     }
 }
 
@@ -218,6 +321,105 @@ fn painter_animated(
                     rgb::animate_rgb(channels, cur, lk.maze.offset());
                     lk.maze[cur.row as usize][cur.col as usize] |= rgb::PAINT;
                     lk.count += 1;
+                }
+            }
+            Err(p) => print::maze_panic!("Thread panicked with lock: {}", p),
+        };
+        thread::sleep(time::Duration::from_micros(animation));
+        let mut i = guide.bias;
+        while {
+            let p = &maze::CARDINAL_DIRECTIONS[i];
+            let next = maze::Point {
+                row: cur.row + p.row,
+                col: cur.col + p.col,
+            };
+            if match monitor.lock() {
+                Err(p) => print::maze_panic!("Panic with lock: {}", p),
+                Ok(lk) => (lk.maze[next.row as usize][next.col as usize] & maze::PATH_BIT) != 0,
+            } && !seen.contains(&next)
+            {
+                seen.insert(next);
+                bfs.push_back(next);
+            }
+            i = (i + 1) % rgb::NUM_PAINTERS;
+            i != guide.bias
+        } {}
+    }
+}
+
+fn painter_mini_animated(
+    monitor: solve::SolverMonitor,
+    guide: rgb::ThreadGuide,
+    animation: rgb::SpeedUnit,
+) {
+    let mut seen = HashSet::from([guide.p]);
+    let mut bfs = VecDeque::from([guide.p]);
+    while let Some(cur) = bfs.pop_front() {
+        match monitor.lock() {
+            Ok(mut lk) => {
+                if lk.maze.exit() || lk.count == lk.map.distances.len() {
+                    return;
+                }
+                if (lk.maze[cur.row as usize][cur.col as usize] & rgb::PAINT) == 0 {
+                    let run = lk
+                        .map
+                        .distances
+                        .get(&cur)
+                        .expect("Could not find map entry?");
+                    let intensity = (lk.map.max - run) as f64 / lk.map.max as f64;
+                    let dark = (255f64 * intensity) as u8;
+                    let bright = 128 + (127f64 * intensity) as u8;
+                    let mut channels: rgb::Rgb = [dark, dark, dark];
+                    channels[guide.color_i] = bright;
+                    lk.maze[cur.row as usize][cur.col as usize] |= rgb::PAINT;
+                    lk.count += 1;
+                    if cur.row % 2 == 0 {
+                        if (lk.maze[(cur.row + 1) as usize][cur.col as usize] & maze::PATH_BIT) != 0
+                        {
+                            let neighbor = maze::Point {
+                                row: cur.row + 1,
+                                col: cur.col,
+                            };
+                            lk.maze[neighbor.row as usize][neighbor.col as usize] |= rgb::PAINT;
+                            let neighbor_dist = lk.map.distances.get(&neighbor).expect("Empty map");
+                            let intensity = (lk.map.max - neighbor_dist) as f64 / lk.map.max as f64;
+                            let dark = (255f64 * intensity) as u8;
+                            let bright = 128 + (127f64 * intensity) as u8;
+                            let mut neighbor_channels: rgb::Rgb = [dark, dark, dark];
+                            neighbor_channels[guide.color_i] = bright;
+                            rgb::animate_mini_rgb(
+                                Some(channels),
+                                Some(neighbor_channels),
+                                cur,
+                                lk.maze.offset(),
+                            );
+                        } else {
+                            rgb::animate_mini_rgb(Some(channels), None, cur, lk.maze.offset());
+                        }
+                    } else {
+                        if (lk.maze[(cur.row - 1) as usize][cur.col as usize] & maze::PATH_BIT) != 0
+                        {
+                            let neighbor = maze::Point {
+                                row: cur.row - 1,
+                                col: cur.col,
+                            };
+                            lk.maze[neighbor.row as usize][neighbor.col as usize] |= rgb::PAINT;
+                            let neighbor_dist = lk.map.distances.get(&neighbor).expect("Empty map");
+                            let intensity = (lk.map.max - neighbor_dist) as f64 / lk.map.max as f64;
+                            let dark = (255f64 * intensity) as u8;
+                            let bright = 128 + (127f64 * intensity) as u8;
+                            let mut neighbor_channels: rgb::Rgb = [dark, dark, dark];
+                            neighbor_channels[guide.color_i] = bright;
+                            rgb::animate_mini_rgb(
+                                Some(neighbor_channels),
+                                Some(channels),
+                                cur,
+                                lk.maze.offset(),
+                            );
+                        } else {
+                            rgb::animate_mini_rgb(None, Some(channels), cur, lk.maze.offset());
+                        }
+                    }
                 }
             }
             Err(p) => print::maze_panic!("Thread panicked with lock: {}", p),

--- a/maze_progs/res/instructions.txt
+++ b/maze_progs/res/instructions.txt
@@ -1,79 +1,80 @@
-                                                             ██████████████████████████████████   
-███╗   ███╗ █████╗ ███████╗███████╗  ████████╗██╗   ██╗██╗   ██████████████████████████████████  
-████╗ ████║██╔══██╗╚══███╔╝██╔════╝  ╚══██╔══╝██║   ██║██║   █████████████████████▓████████████
-██╔████╔██║███████║  ███╔╝ █████╗       ██║   ██║   ██║██║   ██▓██████▓████▓███████████████████  
-██║╚██╔╝██║██╔══██║ ███╔╝  ██╔══╝       ██║   ██║   ██║██║   ███████████████████▓██████████████
-██║ ╚═╝ ██║██║  ██║███████╗███████╗     ██║   ╚██████╔╝██║   ██████▓██▓███▓██▓████▓███▓████████
-╚═╝     ╚═╝╚═╝  ╚═╝╚══════╝╚══════╝     ╚═╝    ╚═════╝ ╚═╝   █▓█▓██▓▓██▓███████████████████████
-                                                             ████▓█▓▓▓█▓██▓████▓█████▓█████████
-Use flags, followed by arguments, in any order.              ██▓█▓▓▓▓██▓████▓████████▓█████████
-Press <ENTER> to confirm your flag choices.                  ▓▓████▓▓██▓████▓████▓██▓▓███▓█████ 
-                                                             ▓██▓▓█▓▓██▓█▓██▓▓██████▓▓███▓█████ 
-(scroll with <↓>/<↑>, exit with <ESC>)                       ▓▓▓█▓█▓▓██▓████▓▓███▓██▓▓███▓█████ 
-                                                             ▓▓█▓▓█▓▓██▓██▓█▓▓▓██▓██▓▓▓██▓█████  
-BUILDER FLAG[-b] Set maze building algorithm.                ▓▓██▓█▓▓██▓████▓▓▓██▓██▓▓▓██▓█████  
-    [rdfs] - Randomized Depth First Search.                  ▓▓█▓▓▓▓▓██▒█▓██▒▓▓██▓██▓▓▓██▓█████  
-    [kruskal] - Randomized Kruskal's algorithm.              ▓▓██▓▓▓▓██▒▓██▓▒▓▓██▓██▓▓▓██▓█████   
-    [prim] - Randomized Prim's algorithm.                    ▓▓██▓▓▒▓█▓▒▓██▓▒▓▓██▓██▓▓▓██▓█████   
-    [eller] - Randomized Eller's algorithm.                  ▓▓██▓▓▒▓█▓▒▓▓█▓▒▓▓██▓██▓▒▓██▓█████
-    [wilson] - Loop-Erased Random Path Carver.               ▓▓██▓▓▒▒█▓▒▓▓█▓▒▓▓██▓██▓▒▓██▓█████   
-    [wilson-walls] - Loop-Erased Random Wall Adder.          ▒▓██▓▓▒▒█▓▒▓▓█▓▒▓▓██▓██▓▒▓██▓█████   
-    [fractal] - Randomized recursive subdivision.            ▒▓██▓▓▒▒▓▓▒▓▓█▓▒▓▓██▓██▓▒▓██▓█████
-    [grid] - A random grid pattern.                          ▒▒█▓▓▓▒▒▓▒▒▓▓█▓▒▓▓█▓▒██▓▒▓█▓▓▓████
-    [arena] - Open floor with no walls.                      ▒▒█▓▓▓▒▒▓▒▒▓▓█▓▒▓▓█▓▒▓█▓▒▓██▓▓████
-                                                             ▒▒▓▓▓▓▒▒▓▒▒▓▓█▓▒▓▓█▓▒▓█▓▒▓██▓▓████
-MODIFICATION FLAG[-m] Add shortcuts to the maze.             ▒▒▓▓▓▓▒▒▓▒░▓▓█▓▒▒▓█▓▒▓█▓▒▓██▓▓████ 
-    [cross]- Add crossroads through the center.              ▒▒▓▓▓▓▒▒▓▒░▓▓█▓▒▒▒█▓▒▓█▓▒▓██▓▓████
-    [x]- Add an x of crossing paths through center.          ▒▒▓▓▓▒░▒▓▒░▓▒█▓░▒▒█▓▒▓█▓░▓██▓▓███▓ 
-                                                             ▒▒▓▓▒▒░▒▓▒░▓▒█▓░▒▒█▓▒▓█▓░▓██▓▓███▓    
-SOLVER FLAG[-s] Set maze solving algorithm.                  ▒▒▓▓▒▒░▒▓▒░▓▒█▓░▒▒█▓▒▓█▓░▓██▓▓███▓    
-    [dfs-hunt] - Depth First Search                          ▒▒▓▓░▒░▒▓▒░▓▒▓▓░░▒█▓░▓█▓░▓█▓▒▒███▒    
-    [dfs-gather] - Depth First Search                        ▒▒▓▓░▒░▒▓▒░▓▒▓▓░░▒█▓░▓█▓░▓█▓▒▒███▒
-    [dfs-corners] - Depth First Search                       ▒▒▓▓░▒░▒▓▒░▒▒▓▓░░▒█▓░▓█▓░▓▓▓▒▒███▒
-    [floodfs-hunt] - Depth First Search                      ▒▒▓▓░▒░▒▓▒░▒▒▓▓░░▒█▓░▓█▓░▓▓▓▒▒███▒ 
-    [floodfs-gather] - Depth First Search                    ▒▒▓▓░▒░▒▓▒░▒▒▓▓░░▒█▓░▓█▓░▓▓▓▒▒███▒  
-    [floodfs-corners] - Depth First Search                   ▒▒▓▒░░░▒▓▒░▒▒▓▒░░░█▓░▓█▓░▓▓▓░▒███▒  
-    [rdfs-hunt] - Randomized Depth First Search              ░▒▓▒░░░▒▓▒░▒░▓▒░░░█▓░▓█▓░▓▓▓░▒███▒
-    [rdfs-gather] - Randomized Depth First Search            ░▒▓▒░░░▒▒▒░▒░▓▒░░░▓▓░▓█▒░▓▓▓░▒███▒
-    [rdfs-corners] - Randomized Depth First Search           ░▒▓▒░░░▒▒▒░▒░▓▒░░░▓▓░▓█▒░▓▓▓░▒███▒
-    [bfs-hunt] - Breadth First Search                        ░░▒▒░░░▒▒▒░▒░▓▒░░░▓▓░▓█▒░▓▓▓░▒███▒ 
-    [bfs-gather] - Breadth First Search                      ░░▒▒░░░░▒▒░▒░▒▒░░░▓▓░▓█▒░▓▓▓░▒███▒  
-    [bfs-corners] - Breadth First Search                     ░░▒▒░░░░▒▒░▒░▒▒░░░▓▓░▓█▒░▓▓▓░▒███▒  
-    [dark[algorithm]-[game]] - A mystery...                  ░░▒▒░░░░▒▒░▒░▒▒░░░▓▓░▓█▒░▓▓▓░▒███▒   
-                                                             ░░▒▒░░░░▒▒░▒░▒▒░░░▓▓░▓█▒░▓▓▓░▒██▓▒      
-WALL FLAG[-w] Set the wall style for the maze.                ░▒▒ ░░░▒▒░▒░▒▒░░░▓▓░▓█▒░▓▓▓░▒██▓▒      
-    [sharp] - The default straight lines.                    ░ ▒▒░ ░░▒▒░▒░▒▒░░░▓▓░▓█▒░▓▓▓░▒██▓▒
-    [round] - Rounded corners.                               ░░▒▒ ░ ░▒▒░▒░▒▒░░░▓▓░▓█▒░▓▓▓░▒▓█▓▒ 
-    [doubles] - Sharp double lines.                          ░░▒▒    ░▒░▒░▒▒░░░▓▓░▓█▒░▓▓▓░▒▓█▓▒    
-    [bold] - Thicker straight lines.                         ░ ▒▒░ ░ ░▒░▒░▒▒░░░▓▓░▓▓▒░▓▓▓░▒▓█▓▒    
-    [contrast] - Full block width and height walls.           ░▒░ ░░░░▒░▒░▒▒░░░▓▓░▓▓▒░▓▓▓ ▒▓█▓▒    
-    [half] - Half block height full width squares.            ░▒░ ░░░░▒░▒░▒▒░░░▓▓░▓▓▒░▓▓▓ ▒▓█▓▒    
-    [spikes] - Connected lines with spikes.                  ░░░░  ░░░▒░▒░▒▒░░░▓▓░▒▓▒ ▓▓▓ ▒▓█▒▒     
-                                                             ░░░░ ░ ░░▒░░░▒▒░░░▓▓░▒▓▒ ▓▓▓ ▒▓▓▒▒ 
-SOLVER ANIMATION FLAG[-sa] Watch the maze solution.          ░░░░░ ░░ ░░░ ░▒░░░▓▒░▒▓▒ ▓▒▓ ▒▓▓▒▒ 
-    [1-7] - Speed increases with number.                     ░░░░░░ ░ ░░░ ░▒░░ ▓▒░▒▓▒ ▓▒▓ ▒▓▓▒▒ 
-                                                             ░░░░░░ ░ ░░░ ░▒░  ▒▒ ▒▓▒ ▒▒▓ ▒▓▓▒▒   
-BUILDER ANIMATION FLAG[-ba] Watch the maze build.            ░░░░░ ░ ░░░░ ░▒   ▒▒ ▒▓▒ ▒▒▓ ▒▓▓▒▒       
-    [1-7] - Speed increases with number.                     ░ ░░ ░  ░░░░ ░▒░ ░▒▒ ▒▒▒░▒▒▓ ▒▓▓▒▒        
-                                                             ░  ░░ ░ ░░░  ░▒  ░▒▒ ▒▒▒ ▒▒▓ ▒▓▓▒▒        
-Cancel any animation by pressing any key.                     ░ ░   ░░░░ ░░▒ ░ ▒▒ ▒▒▒ ▒▒▒ ▒▓▒░▒         
-Zoom out/in with <Ctrl-[-]>/<Ctrl-[+]>                       ░  ░ ░  ░ ░░ ░▒   ▒▒ ▒▒░ ▒▒▒ ▒▓▒░░ 
-If any flags are omitted, defaults are used.                 ░  ░░░  ░ ░  ░░   ▒▒ ▒▒░ ▒▒▒ ▒▓▒░░
-An empty command line will create a random maze.               ░░ ░  ░ ░   ░░  ▒░ ▒▒  ▒▒▒ ▒▓▒░░ 
-                                                             ░  ░░  ░░    ░░░  ▒░ ░▒  ▒▒▒ ▒▓▒░░ 
-EXAMPLES:                                                      ░  ░ ░░  ░  ░   ▒  ░▒  ▒▒▒ ░▓▒░░  
-                                                              ░ ░ ░ ░░░ ░  ░ ░ ▒  ░▒  ▒▒▒ ░▒▒░░ 
--b rdfs -s bfs-hunt                                             ░   ░░░ ░  ░  ░▒  ░░  ▒▒▒ ░▒░░ 
--s bfs-gather -b prim                                         ░ ░  ░ ░░    ░ ░ ░  ░░  ░▒▒ ░▒░░  
--s bfs-corners -d round -b fractal                           ░░ ░    ░░ ░ ░░░  ░  ░░  ░▒▒ ░▒░  
--s dfs-hunt -ba 4 -sa 5 -b wilson-walls -m x                  ░ ░░ ░ ░░  ░ ░░  ░  ░░  ░▒▒ ░▒░ ░
-                                                               ░░    ░  ░ ░    ░   ░  ░░▒ ░▒░   
-ASCII lettering for this title and algorithm                  ░ ░  ░      ░ ░  ░   ░  ░░▒ ░░░   
-descriptions are templates I used from                         ░  ░ ░  ░  ░   ░░   ░  ░░▒ ░░░ ░    
-patorjk.com and modified to use box-drawing                     ░ ░   ░        ░░  ░ ░░░░ ░░░  
-characters.                                                     ░    ░   ░    ░░   ░  ░░░ ░░░  ░
-                                                                 ░    ░          ░    ░ ░ ░░    
-Enjoy!                                                          ░  ░   ░               ░   ░░   
+                                                             ███████████████████████████████████   
+███╗   ███╗ █████╗ ███████╗███████╗  ████████╗██╗   ██╗██╗   ███████████████████████████████████  
+████╗ ████║██╔══██╗╚══███╔╝██╔════╝  ╚══██╔══╝██║   ██║██║   █████████████████████▓█████████████
+██╔████╔██║███████║  ███╔╝ █████╗       ██║   ██║   ██║██║   ██▓██████▓████▓████████████████████  
+██║╚██╔╝██║██╔══██║ ███╔╝  ██╔══╝       ██║   ██║   ██║██║   ███████████████████▓███████████████
+██║ ╚═╝ ██║██║  ██║███████╗███████╗     ██║   ╚██████╔╝██║   ██████▓██▓███▓██▓████▓███▓█████████
+╚═╝     ╚═╝╚═╝  ╚═╝╚══════╝╚══════╝     ╚═╝    ╚═════╝ ╚═╝   █▓█▓██▓▓██▓████████████████████████
+                                                             ████▓█▓▓▓█▓██▓████▓█████▓██████████
+Use flags, followed by arguments, in any order.              ██▓█▓▓▓▓██▓████▓████████▓██████████
+Press <ENTER> to confirm your flag choices.                  ▓▓████▓▓██▓████▓████▓██▓▓███▓██████ 
+                                                             ▓██▓▓█▓▓██▓█▓██▓▓██████▓▓███▓██████ 
+(scroll with <↓>/<↑>, exit with <ESC>)                       ▓▓▓█▓█▓▓██▓████▓▓███▓██▓▓███▓██████ 
+                                                             ▓▓█▓▓█▓▓██▓██▓█▓▓▓██▓██▓▓▓██▓██████  
+BUILDER FLAG[-b] Set maze building algorithm.                ▓▓██▓█▓▓██▓████▓▓▓██▓██▓▓▓██▓██████  
+    [rdfs] - Randomized Depth First Search.                  ▓▓█▓▓▓▓▓██▒█▓██▒▓▓██▓██▓▓▓██▓██████  
+    [kruskal] - Randomized Kruskal's algorithm.              ▓▓██▓▓▓▓██▒▓██▓▒▓▓██▓██▓▓▓██▓██████   
+    [prim] - Randomized Prim's algorithm.                    ▓▓██▓▓▒▓█▓▒▓██▓▒▓▓██▓██▓▓▓██▓██████   
+    [eller] - Randomized Eller's algorithm.                  ▓▓██▓▓▒▓█▓▒▓▓█▓▒▓▓██▓██▓▒▓██▓█████▓
+    [wilson] - Loop-Erased Random Path Carver.               ▓▓██▓▓▒▒█▓▒▓▓█▓▒▓▓██▓██▓▒▓██▓█████▓   
+    [wilson-walls] - Loop-Erased Random Wall Adder.          ▒▓██▓▓▒▒█▓▒▓▓█▓▒▓▓██▓██▓▒▓██▓█████▓   
+    [fractal] - Randomized recursive subdivision.            ▒▓██▓▓▒▒▓▓▒▓▓█▓▒▓▓██▓██▓▒▓██▓█████▓
+    [grid] - A random grid pattern.                          ▒▒█▓▓▓▒▒▓▒▒▓▓█▓▒▓▓█▓▒██▓▒▓█▓▓▓████▓
+    [arena] - Open floor with no walls.                      ▒▒█▓▓▓▒▒▓▒▒▓▓█▓▒▓▓█▓▒▓█▓▒▓██▓▓████▓
+                                                             ▒▒▓▓▓▓▒▒▓▒▒▓▓█▓▒▓▓█▓▒▓█▓▒▓██▓▓████▓
+MODIFICATION FLAG[-m] Add shortcuts to the maze.             ▒▒▓▓▓▓▒▒▓▒░▓▓█▓▒▒▓█▓▒▓█▓▒▓██▓▓████▓ 
+    [cross]- Add crossroads through the center.              ▒▒▓▓▓▓▒▒▓▒░▓▓█▓▒▒▒█▓▒▓█▓▒▓██▓▓████▓
+    [x]- Add an x of crossing paths through center.          ▒▒▓▓▓▒░▒▓▒░▓▒█▓░▒▒█▓▒▓█▓░▓██▓▓███▓▓ 
+                                                             ▒▒▓▓▒▒░▒▓▒░▓▒█▓░▒▒█▓▒▓█▓░▓██▓▓███▓▓    
+SOLVER FLAG[-s] Set maze solving algorithm.                  ▒▒▓▓▒▒░▒▓▒░▓▒█▓░▒▒█▓▒▓█▓░▓██▓▓███▓▓    
+    [dfs-hunt] - Depth First Search                          ▒▒▓▓░▒░▒▓▒░▓▒▓▓░░▒█▓░▓█▓░▓█▓▒▒███▓▒    
+    [dfs-gather] - Depth First Search                        ▒▒▓▓░▒░▒▓▒░▓▒▓▓░░▒█▓░▓█▓░▓█▓▒▒███▓▒
+    [dfs-corners] - Depth First Search                       ▒▒▓▓░▒░▒▓▒░▒▒▓▓░░▒█▓░▓█▓░▓▓▓▒▒███▓▒
+    [floodfs-hunt] - Depth First Search                      ▒▒▓▓░▒░▒▓▒░▒▒▓▓░░▒█▓░▓█▓░▓▓▓▒▒███▓▒ 
+    [floodfs-gather] - Depth First Search                    ▒▒▓▓░▒░▒▓▒░▒▒▓▓░░▒█▓░▓█▓░▓▓▓▒▒███▓▒  
+    [floodfs-corners] - Depth First Search                   ▒▒▓▒░░░▒▓▒░▒▒▓▒░░░█▓░▓█▓░▓▓▓░▒███▓▒  
+    [rdfs-hunt] - Randomized Depth First Search              ░▒▓▒░░░▒▓▒░▒░▓▒░░░█▓░▓█▓░▓▓▓░▒███▓▒
+    [rdfs-gather] - Randomized Depth First Search            ░▒▓▒░░░▒▒▒░▒░▓▒░░░▓▓░▓█▒░▓▓▓░▒███▒▒
+    [rdfs-corners] - Randomized Depth First Search           ░▒▓▒░░░▒▒▒░▒░▓▒░░░▓▓░▓█▒░▓▓▓░▒███▒▒
+    [bfs-hunt] - Breadth First Search                        ░░▒▒░░░▒▒▒░▒░▓▒░░░▓▓░▓█▒░▓▓▓░▒███▒▒ 
+    [bfs-gather] - Breadth First Search                      ░░▒▒░░░░▒▒░▒░▒▒░░░▓▓░▓█▒░▓▓▓░▒███▒▒  
+    [bfs-corners] - Breadth First Search                     ░░▒▒░░░░▒▒░▒░▒▒░░░▓▓░▓█▒░▓▓▓░▒███▒▒  
+    [dark[algorithm]-[game]] - A mystery...                  ░░▒▒░░░░▒▒░▒░▒▒░░░▓▓░▓█▒░▓▓▓░▒███▒▒   
+                                                             ░░▒▒░░░░▒▒░▒░▒▒░░░▓▓░▓█▒░▓▓▓░▒██▓▒▒      
+WALL FLAG[-w] Set the wall style for the maze.                ░▒▒ ░░░▒▒░▒░▒▒░░░▓▓░▓█▒░▓▓▓░▒██▓▒▒      
+    [mini] - Half size walls and paths.                      ░ ▒▒░ ░░▒▒░▒░▒▒░░░▓▓░▓█▒░▓▓▓░▒██▓▒▒
+    [sharp] - The default straight lines.                    ░ ▒▒░ ░░▒▒░▒░▒▒░░░▓▓░▓█▒░▓▓▓░▒██▓▒▒
+    [round] - Rounded corners.                               ░░▒▒ ░ ░▒▒░▒░▒▒░░░▓▓░▓█▒░▓▓▓░▒▓█▓▒▒ 
+    [doubles] - Sharp double lines.                          ░░▒▒    ░▒░▒░▒▒░░░▓▓░▓█▒░▓▓▓░▒▓█▓▒▒    
+    [bold] - Thicker straight lines.                         ░ ▒▒░ ░ ░▒░▒░▒▒░░░▓▓░▓▓▒░▓▓▓░▒▓█▓▒▒    
+    [contrast] - Full block width and height walls.           ░▒░ ░░░░▒░▒░▒▒░░░▓▓░▓▓▒░▓▓▓ ▒▓█▓▒▒    
+    [half] - Half block walls full size paths.                ░▒░ ░░░░▒░▒░▒▒░░░▓▓░▓▓▒░▓▓▓ ▒▓█▓▒▒    
+    [spikes] - Connected lines with spikes.                  ░░░░  ░░░▒░▒░▒▒░░░▓▓░▒▓▒ ▓▓▓ ▒▓█▒▒▒     
+                                                             ░░░░ ░ ░░▒░░░▒▒░░░▓▓░▒▓▒ ▓▓▓ ▒▓▓▒▒▒ 
+SOLVER ANIMATION FLAG[-sa] Watch the maze solution.          ░░░░░ ░░ ░░░ ░▒░░░▓▒░▒▓▒ ▓▒▓ ▒▓▓▒▒▒ 
+    [1-7] - Speed increases with number.                     ░░░░░░ ░ ░░░ ░▒░░ ▓▒░▒▓▒ ▓▒▓ ▒▓▓▒▒▒ 
+                                                             ░░░░░░ ░ ░░░ ░▒░  ▒▒ ▒▓▒ ▒▒▓ ▒▓▓▒▒▒   
+BUILDER ANIMATION FLAG[-ba] Watch the maze build.            ░░░░░ ░ ░░░░ ░▒   ▒▒ ▒▓▒ ▒▒▓ ▒▓▓▒▒▒       
+    [1-7] - Speed increases with number.                     ░ ░░ ░  ░░░░ ░▒░ ░▒▒ ▒▒▒░▒▒▓ ▒▓▓▒▒▒        
+                                                             ░  ░░ ░ ░░░  ░▒  ░▒▒ ▒▒▒ ▒▒▓ ▒▓▓▒▒▒        
+Cancel any animation by pressing any key.                     ░ ░   ░░░░ ░░▒ ░ ▒▒ ▒▒▒ ▒▒▒ ▒▓▒░▒▒         
+Zoom out/in with <Ctrl-[-]>/<Ctrl-[+]>                       ░  ░ ░  ░ ░░ ░▒   ▒▒ ▒▒░ ▒▒▒ ▒▓▒░░░ 
+If any flags are omitted, defaults are used.                 ░  ░░░  ░ ░  ░░   ▒▒ ▒▒░ ▒▒▒ ▒▓▒░░░
+An empty command line will create a random maze.               ░░ ░  ░ ░   ░░  ▒░ ▒▒  ▒▒▒ ▒▓▒░░░ 
+                                                             ░  ░░  ░░    ░░░  ▒░ ░▒  ▒▒▒ ▒▓▒░░░ 
+EXAMPLES:                                                      ░  ░ ░░  ░  ░   ▒  ░▒  ▒▒▒ ░▓▒░░░  
+                                                              ░ ░ ░ ░░░ ░  ░ ░ ▒  ░▒  ▒▒▒ ░▒▒░░░ 
+-b rdfs -s bfs-hunt                                             ░   ░░░ ░  ░  ░▒  ░░  ▒▒▒ ░▒░░░  
+-s bfs-gather -b prim                                         ░ ░  ░ ░░    ░ ░ ░  ░░  ░▒▒ ░▒░░░   
+-s bfs-corners -d round -b fractal                           ░░ ░    ░░ ░ ░░░  ░  ░░  ░▒▒ ░▒░ ░  
+-s dfs-hunt -ba 4 -sa 5 -b wilson-walls -m x                  ░ ░░ ░ ░░  ░ ░░  ░  ░░  ░▒▒ ░▒░ ░░
+                                                               ░░    ░  ░ ░    ░   ░  ░░▒ ░▒░ ░   
+ASCII lettering for this title and algorithm                  ░ ░  ░      ░ ░  ░   ░  ░░▒ ░░░ ░   
+descriptions are templates I used from                         ░  ░ ░  ░  ░   ░░   ░  ░░▒ ░░░ ░░    
+patorjk.com and modified to use box-drawing                     ░ ░   ░        ░░  ░ ░░░░ ░░░ ░  
+characters.                                                     ░    ░   ░    ░░   ░  ░░░ ░░░   
+                                                                 ░    ░          ░    ░ ░ ░░  ░   
+Enjoy!                                                          ░  ░   ░               ░   ░ ░  
                                                                   
                                                                 ░  ░
                                                                  ░

--- a/maze_progs/run_maze/src/main.rs
+++ b/maze_progs/run_maze/src/main.rs
@@ -9,8 +9,8 @@ fn main() {
     let invisible = print::InvisibleCursor::new();
     invisible.hide();
     ctrlc::set_handler(move || {
-        print::clear_screen();
-        print::set_cursor_position(maze::Point::default(), maze::Offset::default());
+        //print::clear_screen();
+        print::set_cursor_position(maze::Point { row: 50, col: 111 }, maze::Offset::default());
         print::unhide_cursor_on_process_exit();
         std::process::exit(0);
     })
@@ -40,12 +40,22 @@ fn main() {
                 process_current = true;
                 prev_flag = flag;
             }
-            None => {
-                quit(&err_string(&tables::FlagArg {
-                    flag: &a,
-                    arg: "[NONE]",
-                }));
-            }
+            None => match &*a {
+                "-r" => {
+                    process_current = true;
+                    prev_flag = "-r";
+                }
+                "-c" => {
+                    process_current = true;
+                    prev_flag = "-c";
+                }
+                _ => {
+                    quit(&err_string(&tables::FlagArg {
+                        flag: &a,
+                        arg: "[NONE]",
+                    }));
+                }
+            },
         }
     }
     if process_current {

--- a/maze_progs/run_maze/src/main.rs
+++ b/maze_progs/run_maze/src/main.rs
@@ -90,24 +90,24 @@ fn main() {
 
     // Commented out for testing builders only right now.
 
-    // let monitor = solve::Solver::new(maze);
+    let monitor = solve::Solver::new(maze);
 
-    // match run.solve_view {
-    //     tables::ViewingMode::StaticImage => {
-    //         run.solve.0(monitor.clone());
-    //     }
-    //     tables::ViewingMode::AnimatedPlayback => run.solve.1(monitor.clone(), run.solve_speed),
-    // }
+    match run.solve_view {
+        tables::ViewingMode::StaticImage => {
+            run.solve.0(monitor.clone());
+        }
+        tables::ViewingMode::AnimatedPlayback => run.solve.1(monitor.clone(), run.solve_speed),
+    }
 
-    // if let Ok(lk) = monitor.clone().lock() {
-    //     print::set_cursor_position(
-    //         maze::Point {
-    //             row: lk.maze.row_size() + 2,
-    //             col: 0,
-    //         },
-    //         maze::Offset::default(),
-    //     );
-    // }
+    if let Ok(lk) = monitor.clone().lock() {
+        print::set_cursor_position(
+            maze::Point {
+                row: lk.maze.row_size() + 2,
+                col: 0,
+            },
+            maze::Offset::default(),
+        );
+    }
 }
 
 fn set_arg(run: &mut tables::MazeRunner, args: &tables::FlagArg) -> Result<(), String> {

--- a/maze_progs/run_maze/src/main.rs
+++ b/maze_progs/run_maze/src/main.rs
@@ -75,22 +75,15 @@ fn main() {
     match run.build_view {
         tables::ViewingMode::StaticImage => {
             run.build.0(&mut maze);
-            if let Some((static_mod, _, _)) = run.modify {
+            if let Some((static_mod, _)) = run.modify {
                 static_mod(&mut maze)
             }
             flush_grid(&maze);
         }
         tables::ViewingMode::AnimatedPlayback => {
-            if run.args.style == maze::MazeStyle::Mini {
-                run.build.2(&mut maze, run.build_speed);
-                if let Some((_, _, mini_mod)) = run.modify {
-                    mini_mod(&mut maze, run.build_speed)
-                }
-            } else {
-                run.build.1(&mut maze, run.build_speed);
-                if let Some((_, animate_mod, _)) = run.modify {
-                    animate_mod(&mut maze, run.build_speed)
-                }
+            run.build.1(&mut maze, run.build_speed);
+            if let Some((_, animate_mod)) = run.modify {
+                animate_mod(&mut maze, run.build_speed)
             }
         }
     }
@@ -104,13 +97,7 @@ fn main() {
         tables::ViewingMode::StaticImage => {
             run.solve.0(monitor.clone());
         }
-        tables::ViewingMode::AnimatedPlayback => {
-            if run.args.style == maze::MazeStyle::Mini {
-                run.solve.2(monitor.clone(), run.solve_speed);
-            } else {
-                run.solve.1(monitor.clone(), run.solve_speed);
-            }
-        }
+        tables::ViewingMode::AnimatedPlayback => run.solve.1(monitor.clone(), run.solve_speed),
     }
 
     if let Ok(lk) = monitor.clone().lock() {

--- a/maze_progs/run_maze/src/main.rs
+++ b/maze_progs/run_maze/src/main.rs
@@ -86,25 +86,28 @@ fn main() {
     }
 
     // Ensure a smooth transition from build to solve with no flashing.
-    print::set_cursor_position(maze::Point::default(), maze::Offset::default());
-    let monitor = solve::Solver::new(maze);
+    print::set_cursor_position(maze::Point { row: 50, col: 0 }, maze::Offset::default());
 
-    match run.solve_view {
-        tables::ViewingMode::StaticImage => {
-            run.solve.0(monitor.clone());
-        }
-        tables::ViewingMode::AnimatedPlayback => run.solve.1(monitor.clone(), run.solve_speed),
-    }
+    // Commented out for testing builders only right now.
 
-    if let Ok(lk) = monitor.clone().lock() {
-        print::set_cursor_position(
-            maze::Point {
-                row: lk.maze.row_size() + 2,
-                col: 0,
-            },
-            maze::Offset::default(),
-        );
-    }
+    // let monitor = solve::Solver::new(maze);
+
+    // match run.solve_view {
+    //     tables::ViewingMode::StaticImage => {
+    //         run.solve.0(monitor.clone());
+    //     }
+    //     tables::ViewingMode::AnimatedPlayback => run.solve.1(monitor.clone(), run.solve_speed),
+    // }
+
+    // if let Ok(lk) = monitor.clone().lock() {
+    //     print::set_cursor_position(
+    //         maze::Point {
+    //             row: lk.maze.row_size() + 2,
+    //             col: 0,
+    //         },
+    //         maze::Offset::default(),
+    //     );
+    // }
 }
 
 fn set_arg(run: &mut tables::MazeRunner, args: &tables::FlagArg) -> Result<(), String> {

--- a/maze_progs/run_maze/src/main.rs
+++ b/maze_progs/run_maze/src/main.rs
@@ -72,15 +72,22 @@ fn main() {
     match run.build_view {
         tables::ViewingMode::StaticImage => {
             run.build.0(&mut maze);
-            flush_grid(&maze);
-            if let Some((static_mod, _)) = run.modify {
+            if let Some((static_mod, _, _)) = run.modify {
                 static_mod(&mut maze)
             }
+            flush_grid(&maze);
         }
         tables::ViewingMode::AnimatedPlayback => {
-            run.build.1(&mut maze, run.build_speed);
-            if let Some((_, animate_mod)) = run.modify {
-                animate_mod(&mut maze, run.build_speed)
+            if run.args.style == maze::MazeStyle::Mini {
+                run.build.2(&mut maze, run.build_speed);
+                if let Some((_, _, mini_mod)) = run.modify {
+                    mini_mod(&mut maze, run.build_speed)
+                }
+            } else {
+                run.build.1(&mut maze, run.build_speed);
+                if let Some((_, animate_mod, _)) = run.modify {
+                    animate_mod(&mut maze, run.build_speed)
+                }
             }
         }
     }
@@ -96,7 +103,13 @@ fn main() {
         tables::ViewingMode::StaticImage => {
             run.solve.0(monitor.clone());
         }
-        tables::ViewingMode::AnimatedPlayback => run.solve.1(monitor.clone(), run.solve_speed),
+        tables::ViewingMode::AnimatedPlayback => {
+            if run.args.style == maze::MazeStyle::Mini {
+                run.solve.2(monitor.clone(), run.solve_speed);
+            } else {
+                run.solve.1(monitor.clone(), run.solve_speed);
+            }
+        }
     }
 
     if let Ok(lk) = monitor.clone().lock() {

--- a/maze_progs/run_maze/src/main.rs
+++ b/maze_progs/run_maze/src/main.rs
@@ -64,6 +64,9 @@ fn main() {
             arg: "[NONE]",
         }));
     }
+    if run.args.style == maze::MazeStyle::Mini {
+        run.args.odd_rows *= 2;
+    }
 
     let mut maze = maze::Maze::new(run.args);
 
@@ -95,8 +98,6 @@ fn main() {
     // Ensure a smooth transition from build to solve with no flashing.
     print::set_cursor_position(maze::Point { row: 50, col: 0 }, maze::Offset::default());
 
-    // Commented out for testing builders only right now.
-
     let monitor = solve::Solver::new(maze);
 
     match run.solve_view {
@@ -115,7 +116,11 @@ fn main() {
     if let Ok(lk) = monitor.clone().lock() {
         print::set_cursor_position(
             maze::Point {
-                row: lk.maze.row_size() + 2,
+                row: if lk.maze.style_index() == (maze::MazeStyle::Mini as usize) {
+                    lk.maze.row_size() / 2 + 3
+                } else {
+                    lk.maze.row_size() + 2
+                },
                 col: 0,
             },
             maze::Offset::default(),

--- a/maze_progs/run_tui/src/run.rs
+++ b/maze_progs/run_tui/src/run.rs
@@ -62,35 +62,22 @@ fn run_channels(this_run: tables::MazeRunner, tui: &mut tui::Tui) -> tui::Result
                 tables::ViewingMode::StaticImage => {
                     build::print_overlap_key(&lk.maze);
                     this_run.build.0(&mut lk.maze);
-                    if let Some((static_mod, _, _)) = this_run.modify {
+                    if let Some((static_mod, _)) = this_run.modify {
                         static_mod(&mut lk.maze);
                     }
                     build::flush_grid(&lk.maze);
                 }
                 tables::ViewingMode::AnimatedPlayback => {
-                    if this_run.args.style == maze::MazeStyle::Mini {
-                        this_run.build.2(&mut lk.maze, this_run.build_speed);
-                        if let Some((_, _, mini_mod)) = this_run.modify {
-                            mini_mod(&mut lk.maze, this_run.build_speed);
-                        }
-                    } else {
-                        this_run.build.1(&mut lk.maze, this_run.build_speed);
-                        if let Some((_, animated_mod, _)) = this_run.modify {
-                            animated_mod(&mut lk.maze, this_run.build_speed);
-                        }
+                    this_run.build.1(&mut lk.maze, this_run.build_speed);
+                    if let Some((_, animated_mod)) = this_run.modify {
+                        animated_mod(&mut lk.maze, this_run.build_speed);
                     }
                 }
             }
         }
         match this_run.solve_view {
             tables::ViewingMode::StaticImage => this_run.solve.0(mc),
-            tables::ViewingMode::AnimatedPlayback => {
-                if this_run.args.style == maze::MazeStyle::Mini {
-                    this_run.solve.2(mc, this_run.solve_speed);
-                } else {
-                    this_run.solve.1(mc, this_run.solve_speed);
-                }
-            }
+            tables::ViewingMode::AnimatedPlayback => this_run.solve.1(mc, this_run.solve_speed),
         }
         match finished_worker.send(true) {
             Ok(_) => {}
@@ -341,7 +328,6 @@ pub static DESCRIPTIONS: [(tables::BuildFunction, &'static str); 9] = [
         (
             builders::arena::generate_maze,
             builders::arena::animate_maze,
-            builders::arena::animate_mini_maze,
         ),
         include_str!("../../res/arena.txt"),
     ),
@@ -349,39 +335,28 @@ pub static DESCRIPTIONS: [(tables::BuildFunction, &'static str); 9] = [
         (
             builders::eller::generate_maze,
             builders::eller::animate_maze,
-            builders::eller::animate_mini_maze,
         ),
         include_str!("../../res/eller.txt"),
     ),
     (
-        (
-            builders::grid::generate_maze,
-            builders::grid::animate_maze,
-            builders::grid::animate_mini_maze,
-        ),
+        (builders::grid::generate_maze, builders::grid::animate_maze),
         include_str!("../../res/grid.txt"),
     ),
     (
         (
             builders::kruskal::generate_maze,
             builders::kruskal::animate_maze,
-            builders::kruskal::animate_mini_maze,
         ),
         include_str!("../../res/kruskal.txt"),
     ),
     (
-        (
-            builders::prim::generate_maze,
-            builders::prim::animate_maze,
-            builders::prim::animate_mini_maze,
-        ),
+        (builders::prim::generate_maze, builders::prim::animate_maze),
         include_str!("../../res/prim.txt"),
     ),
     (
         (
             builders::recursive_backtracker::generate_maze,
             builders::recursive_backtracker::animate_maze,
-            builders::recursive_backtracker::animate_mini_maze,
         ),
         include_str!("../../res/recursive_backtracker.txt"),
     ),
@@ -389,7 +364,6 @@ pub static DESCRIPTIONS: [(tables::BuildFunction, &'static str); 9] = [
         (
             builders::recursive_subdivision::generate_maze,
             builders::recursive_subdivision::animate_maze,
-            builders::recursive_subdivision::animate_mini_maze,
         ),
         include_str!("../../res/recursive_subdivision.txt"),
     ),
@@ -397,7 +371,6 @@ pub static DESCRIPTIONS: [(tables::BuildFunction, &'static str); 9] = [
         (
             builders::wilson_adder::generate_maze,
             builders::wilson_adder::animate_maze,
-            builders::wilson_adder::animate_mini_maze,
         ),
         include_str!("../../res/wilson_adder.txt"),
     ),
@@ -405,7 +378,6 @@ pub static DESCRIPTIONS: [(tables::BuildFunction, &'static str); 9] = [
         (
             builders::wilson_carver::generate_maze,
             builders::wilson_carver::animate_maze,
-            builders::wilson_carver::animate_mini_maze,
         ),
         include_str!("../../res/wilson_carver.txt"),
     ),

--- a/maze_progs/run_tui/src/run.rs
+++ b/maze_progs/run_tui/src/run.rs
@@ -218,6 +218,9 @@ fn set_command_args(tui: &mut tui::Tui, cmd: &String) -> Result<tables::MazeRunn
         .expect("Tui error");
         return Err(Quit::new());
     }
+    if run.args.style == maze::MazeStyle::Mini {
+        run.args.odd_rows = run.args.odd_rows * 2;
+    }
     Ok(run)
 }
 
@@ -295,6 +298,9 @@ fn set_random_args(tui: &mut tui::Tui) -> tables::MazeRunner {
             None => print::maze_panic!("Modification table empty."),
         }
     }
+    if this_run.args.style == maze::MazeStyle::Mini {
+        this_run.args.odd_rows *= 2;
+    }
     this_run
 }
 
@@ -335,7 +341,7 @@ pub static DESCRIPTIONS: [(tables::BuildFunction, &'static str); 9] = [
         (
             builders::arena::generate_maze,
             builders::arena::animate_maze,
-            builders::arena::animate_maze,
+            builders::arena::animate_mini_maze,
         ),
         include_str!("../../res/arena.txt"),
     ),
@@ -343,7 +349,7 @@ pub static DESCRIPTIONS: [(tables::BuildFunction, &'static str); 9] = [
         (
             builders::eller::generate_maze,
             builders::eller::animate_maze,
-            builders::eller::animate_maze,
+            builders::eller::animate_mini_maze,
         ),
         include_str!("../../res/eller.txt"),
     ),
@@ -351,7 +357,7 @@ pub static DESCRIPTIONS: [(tables::BuildFunction, &'static str); 9] = [
         (
             builders::grid::generate_maze,
             builders::grid::animate_maze,
-            builders::grid::animate_maze,
+            builders::grid::animate_mini_maze,
         ),
         include_str!("../../res/grid.txt"),
     ),
@@ -383,7 +389,7 @@ pub static DESCRIPTIONS: [(tables::BuildFunction, &'static str); 9] = [
         (
             builders::recursive_subdivision::generate_maze,
             builders::recursive_subdivision::animate_maze,
-            builders::recursive_subdivision::animate_maze,
+            builders::recursive_subdivision::animate_mini_maze,
         ),
         include_str!("../../res/recursive_subdivision.txt"),
     ),
@@ -391,7 +397,7 @@ pub static DESCRIPTIONS: [(tables::BuildFunction, &'static str); 9] = [
         (
             builders::wilson_adder::generate_maze,
             builders::wilson_adder::animate_maze,
-            builders::wilson_adder::animate_maze,
+            builders::wilson_adder::animate_mini_maze,
         ),
         include_str!("../../res/wilson_adder.txt"),
     ),
@@ -399,7 +405,7 @@ pub static DESCRIPTIONS: [(tables::BuildFunction, &'static str); 9] = [
         (
             builders::wilson_carver::generate_maze,
             builders::wilson_carver::animate_maze,
-            builders::wilson_carver::animate_maze,
+            builders::wilson_carver::animate_mini_maze,
         ),
         include_str!("../../res/wilson_carver.txt"),
     ),

--- a/maze_progs/run_tui/src/run.rs
+++ b/maze_progs/run_tui/src/run.rs
@@ -62,22 +62,35 @@ fn run_channels(this_run: tables::MazeRunner, tui: &mut tui::Tui) -> tui::Result
                 tables::ViewingMode::StaticImage => {
                     build::print_overlap_key(&lk.maze);
                     this_run.build.0(&mut lk.maze);
-                    build::flush_grid(&lk.maze);
-                    if let Some((static_mod, _)) = this_run.modify {
+                    if let Some((static_mod, _, _)) = this_run.modify {
                         static_mod(&mut lk.maze);
                     }
+                    build::flush_grid(&lk.maze);
                 }
                 tables::ViewingMode::AnimatedPlayback => {
-                    this_run.build.1(&mut lk.maze, this_run.build_speed);
-                    if let Some((_, animated_mod)) = this_run.modify {
-                        animated_mod(&mut lk.maze, this_run.build_speed);
+                    if this_run.args.style == maze::MazeStyle::Mini {
+                        this_run.build.2(&mut lk.maze, this_run.build_speed);
+                        if let Some((_, _, mini_mod)) = this_run.modify {
+                            mini_mod(&mut lk.maze, this_run.build_speed);
+                        }
+                    } else {
+                        this_run.build.1(&mut lk.maze, this_run.build_speed);
+                        if let Some((_, animated_mod, _)) = this_run.modify {
+                            animated_mod(&mut lk.maze, this_run.build_speed);
+                        }
                     }
                 }
             }
         }
         match this_run.solve_view {
             tables::ViewingMode::StaticImage => this_run.solve.0(mc),
-            tables::ViewingMode::AnimatedPlayback => this_run.solve.1(mc, this_run.solve_speed),
+            tables::ViewingMode::AnimatedPlayback => {
+                if this_run.args.style == maze::MazeStyle::Mini {
+                    this_run.solve.2(mc, this_run.solve_speed);
+                } else {
+                    this_run.solve.1(mc, this_run.solve_speed);
+                }
+            }
         }
         match finished_worker.send(true) {
             Ok(_) => {}
@@ -322,6 +335,7 @@ pub static DESCRIPTIONS: [(tables::BuildFunction, &'static str); 9] = [
         (
             builders::arena::generate_maze,
             builders::arena::animate_maze,
+            builders::arena::animate_maze,
         ),
         include_str!("../../res/arena.txt"),
     ),
@@ -329,34 +343,46 @@ pub static DESCRIPTIONS: [(tables::BuildFunction, &'static str); 9] = [
         (
             builders::eller::generate_maze,
             builders::eller::animate_maze,
+            builders::eller::animate_maze,
         ),
         include_str!("../../res/eller.txt"),
     ),
     (
-        (builders::grid::generate_maze, builders::grid::animate_maze),
+        (
+            builders::grid::generate_maze,
+            builders::grid::animate_maze,
+            builders::grid::animate_maze,
+        ),
         include_str!("../../res/grid.txt"),
     ),
     (
         (
             builders::kruskal::generate_maze,
             builders::kruskal::animate_maze,
+            builders::kruskal::animate_mini_maze,
         ),
         include_str!("../../res/kruskal.txt"),
     ),
     (
-        (builders::prim::generate_maze, builders::prim::animate_maze),
+        (
+            builders::prim::generate_maze,
+            builders::prim::animate_maze,
+            builders::prim::animate_mini_maze,
+        ),
         include_str!("../../res/prim.txt"),
     ),
     (
         (
             builders::recursive_backtracker::generate_maze,
             builders::recursive_backtracker::animate_maze,
+            builders::recursive_backtracker::animate_mini_maze,
         ),
         include_str!("../../res/recursive_backtracker.txt"),
     ),
     (
         (
             builders::recursive_subdivision::generate_maze,
+            builders::recursive_subdivision::animate_maze,
             builders::recursive_subdivision::animate_maze,
         ),
         include_str!("../../res/recursive_subdivision.txt"),
@@ -365,12 +391,14 @@ pub static DESCRIPTIONS: [(tables::BuildFunction, &'static str); 9] = [
         (
             builders::wilson_adder::generate_maze,
             builders::wilson_adder::animate_maze,
+            builders::wilson_adder::animate_maze,
         ),
         include_str!("../../res/wilson_adder.txt"),
     ),
     (
         (
             builders::wilson_carver::generate_maze,
+            builders::wilson_carver::animate_maze,
             builders::wilson_carver::animate_maze,
         ),
         include_str!("../../res/wilson_carver.txt"),

--- a/maze_progs/run_tui/src/tui.rs
+++ b/maze_progs/run_tui/src/tui.rs
@@ -321,6 +321,9 @@ fn ui_bg_maze(f: &mut Frame<'_>) {
         add_rows: inner.y as i32,
         add_cols: inner.x as i32,
     };
+    if background_maze.args.style == maze::MazeStyle::Mini {
+        background_maze.args.odd_rows *= 2;
+    }
     let mut bg_maze = maze::Maze::new(background_maze.args);
     background_maze.build.0(&mut bg_maze);
     match background_maze.modify {

--- a/maze_progs/solvers/src/bfs.rs
+++ b/maze_progs/solvers/src/bfs.rs
@@ -121,6 +121,66 @@ pub fn animate_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
     print::maze_panic!("Thread panicked with the lock!");
 }
 
+pub fn animate_mini_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    let animation = solve::SOLVER_SPEEDS[speed as usize];
+    let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
+        if lk.maze.exit() {
+            return;
+        }
+        let start = solve::pick_random_point(&lk.maze);
+        lk.maze[start.row as usize][start.col as usize] |= solve::START_BIT;
+        let finish: maze::Point = solve::pick_random_point(&lk.maze);
+        lk.maze[finish.row as usize][finish.col as usize] |= solve::FINISH_BIT;
+        solve::flush_mini_path_coordinate(&lk.maze, finish);
+        thread::sleep(time::Duration::from_micros(animation));
+        start
+    } else {
+        print::maze_panic!("Thread panic.");
+    };
+
+    let mut handles = Vec::with_capacity(solve::NUM_THREADS - 1);
+    for (i_thread, &mask) in solve::THREAD_MASKS.iter().skip(1).enumerate() {
+        let monitor_clone = monitor.clone();
+        handles.push(thread::spawn(move || {
+            animated_mini_hunter(
+                monitor_clone,
+                solve::ThreadGuide {
+                    index: i_thread + 1,
+                    paint: mask,
+                    start: all_start,
+                    speed: animation,
+                },
+            );
+        }));
+    }
+
+    animated_mini_hunter(
+        monitor.clone(),
+        solve::ThreadGuide {
+            index: 0,
+            paint: solve::THREAD_MASKS[0],
+            start: all_start,
+            speed: animation,
+        },
+    );
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    if let Ok(mut lk) = monitor.lock() {
+        for i in 0..lk.win_path.len() {
+            let p = lk.win_path[i];
+            lk.maze[p.0.row as usize][p.0.col as usize] &= !solve::THREAD_MASK;
+            lk.maze[p.0.row as usize][p.0.col as usize] |= p.1;
+            solve::flush_mini_path_coordinate(&lk.maze, p.0);
+            thread::sleep(time::Duration::from_micros(animation));
+        }
+        return;
+    }
+    print::maze_panic!("Thread panicked with the lock!");
+}
+
 pub fn gather(monitor: solve::SolverMonitor) {
     let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
         let start = solve::pick_random_point(&lk.maze);
@@ -206,6 +266,54 @@ pub fn animate_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
         }));
     }
     animated_gatherer(
+        monitor.clone(),
+        solve::ThreadGuide {
+            index: 0,
+            paint: solve::THREAD_MASKS[0],
+            start: all_start,
+            speed: animation,
+        },
+    );
+    for handle in handles {
+        handle.join().unwrap();
+    }
+}
+
+pub fn animate_mini_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    let animation = solve::SOLVER_SPEEDS[speed as usize];
+    let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
+        if lk.maze.exit() {
+            return;
+        }
+        let start = solve::pick_random_point(&lk.maze);
+        lk.maze[start.row as usize][start.col as usize] |= solve::START_BIT;
+        for _ in 0..solve::NUM_GATHER_FINISHES {
+            let finish: maze::Point = solve::pick_random_point(&lk.maze);
+            lk.maze[finish.row as usize][finish.col as usize] |= solve::FINISH_BIT;
+            solve::flush_mini_path_coordinate(&lk.maze, finish);
+            thread::sleep(time::Duration::from_micros(animation));
+        }
+        start
+    } else {
+        print::maze_panic!("Thread panick.");
+    };
+
+    let mut handles = Vec::with_capacity(solve::NUM_THREADS - 1);
+    for (i_thread, &mask) in solve::THREAD_MASKS.iter().skip(1).enumerate() {
+        let monitor_clone = monitor.clone();
+        handles.push(thread::spawn(move || {
+            animated_mini_gatherer(
+                monitor_clone,
+                solve::ThreadGuide {
+                    index: i_thread + 1,
+                    paint: mask,
+                    start: all_start,
+                    speed: animation,
+                },
+            );
+        }));
+    }
+    animated_mini_gatherer(
         monitor.clone(),
         solve::ThreadGuide {
             index: 0,
@@ -364,6 +472,84 @@ pub fn animate_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
     print::maze_panic!("Thread panicked with the lock");
 }
 
+pub fn animate_mini_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    let animation = solve::SOLVER_SPEEDS[speed as usize];
+    let mut all_starts: [maze::Point; 4] = if let Ok(mut lk) = monitor.lock() {
+        if lk.maze.exit() {
+            return;
+        }
+        let all_starts = solve::set_corner_starts(&lk.maze);
+        for s in all_starts {
+            lk.maze[s.row as usize][s.col as usize] |= solve::START_BIT;
+            solve::flush_mini_path_coordinate(&lk.maze, s);
+            thread::sleep(time::Duration::from_micros(animation));
+        }
+        let finish = maze::Point {
+            row: lk.maze.row_size() / 2,
+            col: lk.maze.col_size() / 2,
+        };
+        for p in maze::ALL_DIRECTIONS {
+            let next = maze::Point {
+                row: finish.row + p.row,
+                col: finish.col + p.col,
+            };
+            lk.maze[next.row as usize][next.col as usize] |= maze::PATH_BIT;
+            solve::flush_mini_path_coordinate(&lk.maze, next);
+            thread::sleep(time::Duration::from_micros(animation));
+        }
+        lk.maze[finish.row as usize][finish.col as usize] |= solve::FINISH_BIT;
+        lk.maze[finish.row as usize][finish.col as usize] |= maze::PATH_BIT;
+        solve::flush_mini_path_coordinate(&lk.maze, finish);
+        thread::sleep(time::Duration::from_micros(animation));
+        all_starts
+    } else {
+        print::maze_panic!("Thread panick.");
+    };
+
+    all_starts.shuffle(&mut thread_rng());
+    let mut handles = Vec::with_capacity(solve::NUM_THREADS - 1);
+    for (i_thread, &mask) in solve::THREAD_MASKS.iter().skip(1).enumerate() {
+        let monitor_clone = monitor.clone();
+        handles.push(thread::spawn(move || {
+            animated_mini_hunter(
+                monitor_clone,
+                solve::ThreadGuide {
+                    index: i_thread + 1,
+                    paint: mask,
+                    start: all_starts[i_thread + 1],
+                    speed: animation,
+                },
+            );
+        }));
+    }
+
+    animated_mini_hunter(
+        monitor.clone(),
+        solve::ThreadGuide {
+            index: 0,
+            paint: solve::THREAD_MASKS[0],
+            start: all_starts[0],
+            speed: animation,
+        },
+    );
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    if let Ok(mut lk) = monitor.lock() {
+        for i in 0..lk.win_path.len() {
+            let p = lk.win_path[i];
+            lk.maze[p.0.row as usize][p.0.col as usize] &= !solve::THREAD_MASK;
+            lk.maze[p.0.row as usize][p.0.col as usize] |= p.1;
+            solve::flush_mini_path_coordinate(&lk.maze, p.0);
+            thread::sleep(time::Duration::from_micros(animation));
+        }
+        return;
+    }
+    print::maze_panic!("Thread panicked with the lock");
+}
+
 // Dispatch Functions for each Thread--------------------------------------------------------------
 
 fn hunter(monitor: solve::SolverMonitor, guide: solve::ThreadGuide) {
@@ -463,6 +649,54 @@ fn animated_hunter(monitor: solve::SolverMonitor, guide: solve::ThreadGuide) {
     }
 }
 
+fn animated_mini_hunter(monitor: solve::SolverMonitor, guide: solve::ThreadGuide) {
+    let mut parents = HashMap::from([(guide.start, maze::Point { row: -1, col: -1 })]);
+    let mut bfs: VecDeque<maze::Point> = VecDeque::from([guide.start]);
+    while let Some(mut cur) = bfs.pop_front() {
+        if let Ok(mut lk) = monitor.lock() {
+            if lk.maze.exit() || lk.win.is_some() {
+                return;
+            }
+            if (lk.maze[cur.row as usize][cur.col as usize] & solve::FINISH_BIT) != 0 {
+                lk.maze[cur.row as usize][cur.col as usize] |= guide.paint;
+                lk.win.get_or_insert(guide.index);
+                while cur.row > 0 {
+                    lk.win_path.push((cur, guide.paint));
+                    cur = match parents.get(&cur) {
+                        Some(parent) => *parent,
+                        None => print::maze_panic!("Bfs could not find parent."),
+                    };
+                }
+                return;
+            }
+            lk.maze[cur.row as usize][cur.col as usize] |= guide.paint;
+            solve::flush_mini_path_coordinate(&lk.maze, cur);
+        } else {
+            print::maze_panic!("Thread panicked!");
+        }
+
+        thread::sleep(time::Duration::from_micros(guide.speed));
+
+        let mut i = guide.index;
+        for _ in 0..solve::NUM_DIRECTIONS {
+            let p = &maze::CARDINAL_DIRECTIONS[i];
+            let next = maze::Point {
+                row: cur.row + p.row,
+                col: cur.col + p.col,
+            };
+            if match monitor.lock() {
+                Err(p) => print::maze_panic!("Thread panicked: {}", p),
+                Ok(lk) => (lk.maze[next.row as usize][next.col as usize] & maze::PATH_BIT) != 0,
+            } && !parents.contains_key(&next)
+            {
+                parents.insert(next, cur);
+                bfs.push_back(next);
+            }
+            i = (i + 1) % solve::NUM_DIRECTIONS;
+        }
+    }
+}
+
 fn gatherer(monitor: solve::SolverMonitor, guide: solve::ThreadGuide) {
     let mut parents = HashMap::from([(guide.start, maze::Point { row: -1, col: -1 })]);
     let seen_bit: solve::ThreadCache = guide.paint << 4;
@@ -532,6 +766,58 @@ fn animated_gatherer(monitor: solve::SolverMonitor, guide: solve::ThreadGuide) {
                 (_, _) => {
                     lk.maze[cur.row as usize][cur.col as usize] |= seen_bit | guide.paint;
                     solve::flush_cursor_path_coordinate(&lk.maze, cur);
+                }
+            }
+        } else {
+            print::maze_panic!("Thread panicked!");
+        }
+
+        thread::sleep(time::Duration::from_micros(guide.speed));
+
+        let mut i = guide.index;
+        for _ in 0..solve::NUM_DIRECTIONS {
+            let p = &maze::CARDINAL_DIRECTIONS[i];
+            let next = maze::Point {
+                row: cur.row + p.row,
+                col: cur.col + p.col,
+            };
+            if match monitor.lock() {
+                Err(p) => print::maze_panic!("Thread panicked: {}", p),
+                Ok(lk) => (lk.maze[next.row as usize][next.col as usize] & maze::PATH_BIT) != 0,
+            } && !parents.contains_key(&next)
+            {
+                parents.insert(next, cur);
+                bfs.push_back(next);
+            }
+            i = (i + 1) % solve::NUM_DIRECTIONS;
+        }
+    }
+}
+
+fn animated_mini_gatherer(monitor: solve::SolverMonitor, guide: solve::ThreadGuide) {
+    let mut parents = HashMap::from([(guide.start, maze::Point { row: -1, col: -1 })]);
+    let seen_bit: solve::ThreadCache = guide.paint << 4;
+    let mut bfs: VecDeque<maze::Point> = VecDeque::from([guide.start]);
+    while let Some(cur) = bfs.pop_front() {
+        if let Ok(mut lk) = monitor.lock() {
+            if lk.maze.exit() {
+                return;
+            }
+            let finish = (lk.maze[cur.row as usize][cur.col as usize] & solve::FINISH_BIT) != 0;
+            let first = (lk.maze[cur.row as usize][cur.col as usize] & solve::CACHE_MASK) == 0;
+            // We can only stop looking if we are the first to this finish. Keep looking otherwise.
+            match (finish, first) {
+                (true, true) => {
+                    lk.maze[cur.row as usize][cur.col as usize] |= guide.paint | seen_bit;
+                    solve::flush_mini_path_coordinate(&lk.maze, cur);
+                    return;
+                }
+                (true, false) => {
+                    lk.maze[cur.row as usize][cur.col as usize] |= seen_bit;
+                }
+                (_, _) => {
+                    lk.maze[cur.row as usize][cur.col as usize] |= seen_bit | guide.paint;
+                    solve::flush_mini_path_coordinate(&lk.maze, cur);
                 }
             }
         } else {

--- a/maze_progs/solvers/src/bfs.rs
+++ b/maze_progs/solvers/src/bfs.rs
@@ -62,6 +62,15 @@ pub fn hunt(monitor: solve::SolverMonitor) {
 }
 
 pub fn animate_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    if monitor
+        .lock()
+        .unwrap_or_else(|_| print::maze_panic!("Thread panicked"))
+        .maze
+        .is_mini()
+    {
+        animate_mini_hunt(monitor, speed);
+        return;
+    }
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {
@@ -121,7 +130,7 @@ pub fn animate_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
     print::maze_panic!("Thread panicked with the lock!");
 }
 
-pub fn animate_mini_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
+fn animate_mini_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {
@@ -232,6 +241,15 @@ pub fn gather(monitor: solve::SolverMonitor) {
 }
 
 pub fn animate_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    if monitor
+        .lock()
+        .unwrap_or_else(|_| print::maze_panic!("Thread panicked"))
+        .maze
+        .is_mini()
+    {
+        animate_mini_gather(monitor, speed);
+        return;
+    }
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {
@@ -279,7 +297,7 @@ pub fn animate_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
     }
 }
 
-pub fn animate_mini_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
+fn animate_mini_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {
@@ -395,6 +413,15 @@ pub fn corner(monitor: solve::SolverMonitor) {
 }
 
 pub fn animate_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    if monitor
+        .lock()
+        .unwrap_or_else(|_| print::maze_panic!("Thread panicked"))
+        .maze
+        .is_mini()
+    {
+        animate_mini_corner(monitor, speed);
+        return;
+    }
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let mut all_starts: [maze::Point; 4] = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {
@@ -472,7 +499,7 @@ pub fn animate_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
     print::maze_panic!("Thread panicked with the lock");
 }
 
-pub fn animate_mini_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
+fn animate_mini_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let mut all_starts: [maze::Point; 4] = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {

--- a/maze_progs/solvers/src/darkbfs.rs
+++ b/maze_progs/solvers/src/darkbfs.rs
@@ -66,6 +66,63 @@ pub fn animate_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
     print::maze_panic!("Thread panicked with the lock");
 }
 
+pub fn animate_mini_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    let animation = solve::SOLVER_SPEEDS[speed as usize];
+    let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
+        if lk.maze.exit() {
+            return;
+        }
+        solve::deluminate_maze(&lk.maze);
+        let all_start = solve::pick_random_point(&lk.maze);
+        lk.maze[all_start.row as usize][all_start.col as usize] |= solve::START_BIT;
+        let finish: maze::Point = solve::pick_random_point(&lk.maze);
+        lk.maze[finish.row as usize][finish.col as usize] |= solve::FINISH_BIT;
+        all_start
+    } else {
+        print::maze_panic!("Thread panick.");
+    };
+
+    let mut handles = Vec::with_capacity(solve::NUM_THREADS - 1);
+    for (i_thread, &mask) in solve::THREAD_MASKS.iter().skip(1).enumerate() {
+        let monitor_clone = monitor.clone();
+        handles.push(thread::spawn(move || {
+            animated_mini_hunter(
+                monitor_clone,
+                solve::ThreadGuide {
+                    index: i_thread + 1,
+                    paint: mask,
+                    start: all_start,
+                    speed: animation,
+                },
+            );
+        }));
+    }
+    animated_mini_hunter(
+        monitor.clone(),
+        solve::ThreadGuide {
+            index: 0,
+            paint: solve::THREAD_MASKS[0],
+            start: all_start,
+            speed: animation,
+        },
+    );
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    if let Ok(mut lk) = monitor.lock() {
+        for i in 0..lk.win_path.len() {
+            let p = lk.win_path[i];
+            lk.maze[p.0.row as usize][p.0.col as usize] &= !solve::THREAD_MASK;
+            lk.maze[p.0.row as usize][p.0.col as usize] |= p.1;
+            solve::flush_dark_mini_path_coordinate(&lk.maze, p.0);
+            thread::sleep(time::Duration::from_micros(animation));
+        }
+        return;
+    }
+    print::maze_panic!("Thread panicked with the lock");
+}
+
 pub fn animate_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
@@ -118,6 +175,65 @@ pub fn animate_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
             lk.maze[p.0.row as usize][p.0.col as usize] &= !solve::THREAD_MASK;
             lk.maze[p.0.row as usize][p.0.col as usize] |= p.1;
             solve::flush_cursor_path_coordinate(&lk.maze, p.0);
+            thread::sleep(time::Duration::from_micros(animation));
+        }
+        return;
+    }
+    print::maze_panic!("Thread panicked with the lock!");
+}
+
+pub fn animate_mini_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    let animation = solve::SOLVER_SPEEDS[speed as usize];
+    let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
+        if lk.maze.exit() {
+            return;
+        }
+        solve::deluminate_maze(&lk.maze);
+        let all_start = solve::pick_random_point(&lk.maze);
+        lk.maze[all_start.row as usize][all_start.col as usize] |= solve::START_BIT;
+        for _ in 0..solve::NUM_GATHER_FINISHES {
+            let finish: maze::Point = solve::pick_random_point(&lk.maze);
+            lk.maze[finish.row as usize][finish.col as usize] |= solve::FINISH_BIT;
+        }
+        all_start
+    } else {
+        print::maze_panic!("Thread panick.");
+    };
+
+    let mut handles = Vec::with_capacity(solve::NUM_THREADS - 1);
+    for (i_thread, &mask) in solve::THREAD_MASKS.iter().skip(1).enumerate() {
+        let monitor_clone = monitor.clone();
+        handles.push(thread::spawn(move || {
+            animated_mini_gatherer(
+                monitor_clone,
+                solve::ThreadGuide {
+                    index: i_thread + 1,
+                    paint: mask,
+                    start: all_start,
+                    speed: animation,
+                },
+            );
+        }));
+    }
+    animated_mini_gatherer(
+        monitor.clone(),
+        solve::ThreadGuide {
+            index: 0,
+            paint: solve::THREAD_MASKS[0],
+            start: all_start,
+            speed: animation,
+        },
+    );
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    if let Ok(mut lk) = monitor.lock() {
+        for i in 0..lk.win_path.len() {
+            let p = lk.win_path[i];
+            lk.maze[p.0.row as usize][p.0.col as usize] &= !solve::THREAD_MASK;
+            lk.maze[p.0.row as usize][p.0.col as usize] |= p.1;
+            solve::flush_dark_mini_path_coordinate(&lk.maze, p.0);
             thread::sleep(time::Duration::from_micros(animation));
         }
         return;
@@ -197,6 +313,78 @@ pub fn animate_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
     print::maze_panic!("Thread panicked with the lock!");
 }
 
+pub fn animate_mini_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    let animation = solve::SOLVER_SPEEDS[speed as usize];
+    let mut all_starts: [maze::Point; 4] = if let Ok(mut lk) = monitor.lock() {
+        if lk.maze.exit() {
+            return;
+        }
+        solve::deluminate_maze(&lk.maze);
+        let all_starts = solve::set_corner_starts(&lk.maze);
+        for s in all_starts {
+            lk.maze[s.row as usize][s.col as usize] |= solve::START_BIT;
+        }
+        let finish = maze::Point {
+            row: lk.maze.row_size() / 2,
+            col: lk.maze.col_size() / 2,
+        };
+        for p in maze::ALL_DIRECTIONS {
+            let next = maze::Point {
+                row: finish.row + p.row,
+                col: finish.col + p.col,
+            };
+            lk.maze[next.row as usize][next.col as usize] |= maze::PATH_BIT;
+        }
+        lk.maze[finish.row as usize][finish.col as usize] |= solve::FINISH_BIT;
+        lk.maze[finish.row as usize][finish.col as usize] |= maze::PATH_BIT;
+        all_starts
+    } else {
+        print::maze_panic!("Thread panick.");
+    };
+
+    all_starts.shuffle(&mut thread_rng());
+
+    let mut handles = Vec::with_capacity(solve::NUM_THREADS - 1);
+    for (i_thread, &mask) in solve::THREAD_MASKS.iter().skip(1).enumerate() {
+        let monitor_clone = monitor.clone();
+        handles.push(thread::spawn(move || {
+            animated_mini_hunter(
+                monitor_clone,
+                solve::ThreadGuide {
+                    index: i_thread + 1,
+                    paint: mask,
+                    start: all_starts[i_thread + 1],
+                    speed: animation,
+                },
+            );
+        }));
+    }
+    animated_mini_hunter(
+        monitor.clone(),
+        solve::ThreadGuide {
+            index: 0,
+            paint: solve::THREAD_MASKS[0],
+            start: all_starts[0],
+            speed: animation,
+        },
+    );
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    if let Ok(mut lk) = monitor.lock() {
+        for i in 0..lk.win_path.len() {
+            let p = lk.win_path[i];
+            lk.maze[p.0.row as usize][p.0.col as usize] &= !solve::THREAD_MASK;
+            lk.maze[p.0.row as usize][p.0.col as usize] |= p.1;
+            solve::flush_dark_mini_path_coordinate(&lk.maze, p.0);
+            thread::sleep(time::Duration::from_micros(animation));
+        }
+        return;
+    }
+    print::maze_panic!("Thread panicked with the lock!");
+}
+
 // Dispatch Functions for each Thread--------------------------------------------------------------
 
 fn animated_hunter(monitor: solve::SolverMonitor, guide: solve::ThreadGuide) {
@@ -247,6 +435,54 @@ fn animated_hunter(monitor: solve::SolverMonitor, guide: solve::ThreadGuide) {
     }
 }
 
+fn animated_mini_hunter(monitor: solve::SolverMonitor, guide: solve::ThreadGuide) {
+    let mut parents = HashMap::from([(guide.start, maze::Point { row: -1, col: -1 })]);
+    let mut bfs: VecDeque<maze::Point> = VecDeque::from([guide.start]);
+    while let Some(mut cur) = bfs.pop_front() {
+        if let Ok(mut lk) = monitor.lock() {
+            if lk.maze.exit() || lk.win.is_some() {
+                return;
+            }
+            if (lk.maze[cur.row as usize][cur.col as usize] & solve::FINISH_BIT) != 0 {
+                lk.maze[cur.row as usize][cur.col as usize] |= guide.paint;
+                lk.win.get_or_insert(guide.index);
+                while cur.row > 0 {
+                    lk.win_path.push((cur, guide.paint));
+                    cur = match parents.get(&cur) {
+                        Some(parent) => *parent,
+                        None => print::maze_panic!("Bfs could not find parent."),
+                    };
+                }
+                return;
+            }
+            lk.maze[cur.row as usize][cur.col as usize] |= guide.paint;
+            solve::flush_dark_mini_path_coordinate(&lk.maze, cur);
+        } else {
+            print::maze_panic!("Thread panicked!");
+        }
+
+        thread::sleep(time::Duration::from_micros(guide.speed));
+
+        let mut i = guide.index;
+        for _ in 0..solve::NUM_DIRECTIONS {
+            let p = &maze::CARDINAL_DIRECTIONS[i];
+            let next = maze::Point {
+                row: cur.row + p.row,
+                col: cur.col + p.col,
+            };
+            if match monitor.lock() {
+                Err(p) => print::maze_panic!("Thread panicked: {}", p),
+                Ok(lk) => (lk.maze[next.row as usize][next.col as usize] & maze::PATH_BIT) != 0,
+            } && !parents.contains_key(&next)
+            {
+                parents.insert(next, cur);
+                bfs.push_back(next);
+            }
+            i = (i + 1) % solve::NUM_DIRECTIONS;
+        }
+    }
+}
+
 fn animated_gatherer(monitor: solve::SolverMonitor, guide: solve::ThreadGuide) {
     let mut parents = HashMap::from([(guide.start, maze::Point { row: -1, col: -1 })]);
     let seen_bit: solve::ThreadCache = guide.paint << 4;
@@ -271,6 +507,58 @@ fn animated_gatherer(monitor: solve::SolverMonitor, guide: solve::ThreadGuide) {
                 (_, _) => {
                     lk.maze[cur.row as usize][cur.col as usize] |= seen_bit | guide.paint;
                     solve::flush_cursor_path_coordinate(&lk.maze, cur);
+                }
+            }
+        } else {
+            print::maze_panic!("Thread panicked!");
+        }
+
+        thread::sleep(time::Duration::from_micros(guide.speed));
+
+        let mut i = guide.index;
+        for _ in 0..solve::NUM_DIRECTIONS {
+            let p = &maze::CARDINAL_DIRECTIONS[i];
+            let next = maze::Point {
+                row: cur.row + p.row,
+                col: cur.col + p.col,
+            };
+            if match monitor.lock() {
+                Err(p) => print::maze_panic!("Thread panicked: {}", p),
+                Ok(lk) => (lk.maze[next.row as usize][next.col as usize] & maze::PATH_BIT) != 0,
+            } && !parents.contains_key(&next)
+            {
+                parents.insert(next, cur);
+                bfs.push_back(next);
+            }
+            i = (i + 1) % solve::NUM_DIRECTIONS;
+        }
+    }
+}
+
+fn animated_mini_gatherer(monitor: solve::SolverMonitor, guide: solve::ThreadGuide) {
+    let mut parents = HashMap::from([(guide.start, maze::Point { row: -1, col: -1 })]);
+    let seen_bit: solve::ThreadCache = guide.paint << 4;
+    let mut bfs: VecDeque<maze::Point> = VecDeque::from([guide.start]);
+    while let Some(cur) = bfs.pop_front() {
+        if let Ok(mut lk) = monitor.lock() {
+            if lk.maze.exit() {
+                return;
+            }
+            let finish = (lk.maze[cur.row as usize][cur.col as usize] & solve::FINISH_BIT) != 0;
+            let first = (lk.maze[cur.row as usize][cur.col as usize] & solve::CACHE_MASK) == 0;
+            // We can only stop looking if we are the first to this finish. Keep looking otherwise.
+            match (finish, first) {
+                (true, true) => {
+                    lk.maze[cur.row as usize][cur.col as usize] |= guide.paint | seen_bit;
+                    solve::flush_dark_mini_path_coordinate(&lk.maze, cur);
+                    return;
+                }
+                (true, false) => {
+                    lk.maze[cur.row as usize][cur.col as usize] |= seen_bit;
+                }
+                (_, _) => {
+                    lk.maze[cur.row as usize][cur.col as usize] |= seen_bit | guide.paint;
+                    solve::flush_dark_mini_path_coordinate(&lk.maze, cur);
                 }
             }
         } else {

--- a/maze_progs/solvers/src/darkbfs.rs
+++ b/maze_progs/solvers/src/darkbfs.rs
@@ -10,6 +10,15 @@ use std::{thread, time};
 // Public Solver Functions-------------------------------------------------------------------------
 
 pub fn animate_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    if monitor
+        .lock()
+        .unwrap_or_else(|_| print::maze_panic!("Thread panicked"))
+        .maze
+        .is_mini()
+    {
+        animate_mini_hunt(monitor, speed);
+        return;
+    }
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {
@@ -66,7 +75,7 @@ pub fn animate_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
     print::maze_panic!("Thread panicked with the lock");
 }
 
-pub fn animate_mini_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
+fn animate_mini_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {
@@ -124,6 +133,15 @@ pub fn animate_mini_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
 }
 
 pub fn animate_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    if monitor
+        .lock()
+        .unwrap_or_else(|_| print::maze_panic!("Thread panicked"))
+        .maze
+        .is_mini()
+    {
+        animate_mini_gather(monitor, speed);
+        return;
+    }
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {
@@ -182,7 +200,7 @@ pub fn animate_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
     print::maze_panic!("Thread panicked with the lock!");
 }
 
-pub fn animate_mini_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
+fn animate_mini_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {
@@ -242,6 +260,15 @@ pub fn animate_mini_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
 }
 
 pub fn animate_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    if monitor
+        .lock()
+        .unwrap_or_else(|_| print::maze_panic!("Thread panicked"))
+        .maze
+        .is_mini()
+    {
+        animate_mini_corner(monitor, speed);
+        return;
+    }
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let mut all_starts: [maze::Point; 4] = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {
@@ -313,7 +340,7 @@ pub fn animate_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
     print::maze_panic!("Thread panicked with the lock!");
 }
 
-pub fn animate_mini_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
+fn animate_mini_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let mut all_starts: [maze::Point; 4] = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {

--- a/maze_progs/solvers/src/darkdfs.rs
+++ b/maze_progs/solvers/src/darkdfs.rs
@@ -9,6 +9,15 @@ use std::{thread, time};
 // Public Solver Functions-------------------------------------------------------------------------
 
 pub fn animate_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    if monitor
+        .lock()
+        .unwrap_or_else(|_| print::maze_panic!("Thread panicked"))
+        .maze
+        .is_mini()
+    {
+        animate_mini_hunt(monitor, speed);
+        return;
+    }
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {
@@ -53,7 +62,7 @@ pub fn animate_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
     }
 }
 
-pub fn animate_mini_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
+fn animate_mini_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {
@@ -99,6 +108,15 @@ pub fn animate_mini_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
 }
 
 pub fn animate_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    if monitor
+        .lock()
+        .unwrap_or_else(|_| print::maze_panic!("Thread panicked"))
+        .maze
+        .is_mini()
+    {
+        animate_mini_gather(monitor, speed);
+        return;
+    }
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {
@@ -145,7 +163,7 @@ pub fn animate_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
     }
 }
 
-pub fn animate_mini_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
+fn animate_mini_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {
@@ -193,6 +211,15 @@ pub fn animate_mini_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
 }
 
 pub fn animate_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    if monitor
+        .lock()
+        .unwrap_or_else(|_| print::maze_panic!("Thread panicked"))
+        .maze
+        .is_mini()
+    {
+        animate_mini_corner(monitor, speed);
+        return;
+    }
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let mut corner_starts: [maze::Point; 4] = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {
@@ -252,7 +279,7 @@ pub fn animate_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
     }
 }
 
-pub fn animate_mini_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
+fn animate_mini_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let mut corner_starts: [maze::Point; 4] = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {

--- a/maze_progs/solvers/src/darkdfs.rs
+++ b/maze_progs/solvers/src/darkdfs.rs
@@ -53,6 +53,51 @@ pub fn animate_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
     }
 }
 
+pub fn animate_mini_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    let animation = solve::SOLVER_SPEEDS[speed as usize];
+    let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
+        if lk.maze.exit() {
+            return;
+        }
+        solve::deluminate_maze(&lk.maze);
+        let all_start = solve::pick_random_point(&lk.maze);
+        lk.maze[all_start.row as usize][all_start.col as usize] |= solve::START_BIT;
+        let finish: maze::Point = solve::pick_random_point(&lk.maze);
+        lk.maze[finish.row as usize][finish.col as usize] |= solve::FINISH_BIT;
+        all_start
+    } else {
+        print::maze_panic!("Thread panick.");
+    };
+
+    let mut handles = Vec::with_capacity(solve::NUM_THREADS - 1);
+    for (i_thread, &mask) in solve::THREAD_MASKS.iter().skip(1).enumerate() {
+        let mc = monitor.clone();
+        handles.push(thread::spawn(move || {
+            animated_mini_hunter(
+                mc,
+                solve::ThreadGuide {
+                    index: i_thread + 1,
+                    paint: mask,
+                    start: all_start,
+                    speed: animation,
+                },
+            );
+        }));
+    }
+    animated_mini_hunter(
+        monitor.clone(),
+        solve::ThreadGuide {
+            index: 0,
+            paint: solve::THREAD_MASKS[0],
+            start: all_start,
+            speed: animation,
+        },
+    );
+    for handle in handles {
+        handle.join().unwrap();
+    }
+}
+
 pub fn animate_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
@@ -87,6 +132,53 @@ pub fn animate_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
         }));
     }
     animated_gatherer(
+        monitor.clone(),
+        solve::ThreadGuide {
+            index: 0,
+            paint: solve::THREAD_MASKS[0],
+            start: all_start,
+            speed: animation,
+        },
+    );
+    for handle in handles {
+        handle.join().unwrap();
+    }
+}
+
+pub fn animate_mini_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    let animation = solve::SOLVER_SPEEDS[speed as usize];
+    let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
+        if lk.maze.exit() {
+            return;
+        }
+        solve::deluminate_maze(&lk.maze);
+        let all_start = solve::pick_random_point(&lk.maze);
+        lk.maze[all_start.row as usize][all_start.col as usize] |= solve::START_BIT;
+        for _ in 0..solve::NUM_GATHER_FINISHES {
+            let finish: maze::Point = solve::pick_random_point(&lk.maze);
+            lk.maze[finish.row as usize][finish.col as usize] |= solve::FINISH_BIT;
+        }
+        all_start
+    } else {
+        print::maze_panic!("Thread panick.");
+    };
+
+    let mut handles = Vec::with_capacity(solve::NUM_THREADS - 1);
+    for (i_thread, &mask) in solve::THREAD_MASKS.iter().skip(1).enumerate() {
+        let mc = monitor.clone();
+        handles.push(thread::spawn(move || {
+            animated_mini_gatherer(
+                mc,
+                solve::ThreadGuide {
+                    index: i_thread + 1,
+                    paint: mask,
+                    start: all_start,
+                    speed: animation,
+                },
+            );
+        }));
+    }
+    animated_mini_gatherer(
         monitor.clone(),
         solve::ThreadGuide {
             index: 0,
@@ -160,6 +252,66 @@ pub fn animate_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
     }
 }
 
+pub fn animate_mini_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    let animation = solve::SOLVER_SPEEDS[speed as usize];
+    let mut corner_starts: [maze::Point; 4] = if let Ok(mut lk) = monitor.lock() {
+        if lk.maze.exit() {
+            return;
+        }
+        solve::deluminate_maze(&lk.maze);
+        let corner_starts = solve::set_corner_starts(&lk.maze);
+        for p in corner_starts {
+            lk.maze[p.row as usize][p.col as usize] |= solve::START_BIT;
+        }
+
+        let finish = maze::Point {
+            row: lk.maze.row_size() / 2,
+            col: lk.maze.col_size() / 2,
+        };
+        for d in maze::ALL_DIRECTIONS {
+            let next = maze::Point {
+                row: finish.row + d.row,
+                col: finish.col + d.col,
+            };
+            lk.maze[next.row as usize][next.col as usize] |= maze::PATH_BIT;
+        }
+        lk.maze[finish.row as usize][finish.col as usize] |= maze::PATH_BIT;
+        lk.maze[finish.row as usize][finish.col as usize] |= solve::FINISH_BIT;
+        corner_starts
+    } else {
+        print::maze_panic!("Thread panick.");
+    };
+
+    corner_starts.shuffle(&mut thread_rng());
+    let mut handles = Vec::with_capacity(solve::NUM_THREADS - 1);
+    for (i_thread, &mask) in solve::THREAD_MASKS.iter().skip(1).enumerate() {
+        let mc = monitor.clone();
+        handles.push(thread::spawn(move || {
+            animated_mini_hunter(
+                mc,
+                solve::ThreadGuide {
+                    index: i_thread + 1,
+                    paint: mask,
+                    start: corner_starts[i_thread + 1],
+                    speed: animation,
+                },
+            );
+        }));
+    }
+    animated_mini_hunter(
+        monitor.clone(),
+        solve::ThreadGuide {
+            index: 0,
+            paint: solve::THREAD_MASKS[0],
+            start: corner_starts[0],
+            speed: animation,
+        },
+    );
+    for handle in handles {
+        handle.join().unwrap();
+    }
+}
+
 // Dispatch Functions for each Thread--------------------------------------------------------------
 
 fn animated_hunter(monitor: solve::SolverMonitor, guide: solve::ThreadGuide) {
@@ -212,6 +364,64 @@ fn animated_hunter(monitor: solve::SolverMonitor, guide: solve::ThreadGuide) {
             Ok(mut lk) => {
                 lk.maze[cur.row as usize][cur.col as usize] &= !guide.paint;
                 solve::flush_cursor_path_coordinate(&lk.maze, cur);
+            }
+            Err(p) => print::maze_panic!("Solve thread panic!: {}", p),
+        }
+        thread::sleep(time::Duration::from_micros(guide.speed));
+        dfs.pop();
+    }
+}
+
+fn animated_mini_hunter(monitor: solve::SolverMonitor, guide: solve::ThreadGuide) {
+    let seen: solve::ThreadCache = guide.paint << solve::THREAD_TAG_OFFSET;
+    let mut dfs: Vec<maze::Point> = Vec::with_capacity(solve::INITIAL_PATH_LEN);
+    dfs.push(guide.start);
+    'branching: while let Some(&cur) = dfs.last() {
+        if let Ok(mut lk) = monitor.lock() {
+            if lk.maze.exit() || lk.win.is_some() {
+                return;
+            }
+            if (lk.maze[cur.row as usize][cur.col as usize] & solve::FINISH_BIT) != 0 {
+                lk.maze[cur.row as usize][cur.col as usize] |= guide.paint;
+                solve::flush_dark_mini_path_coordinate(&lk.maze, cur);
+                lk.win.get_or_insert(guide.index);
+                dfs.pop();
+                return;
+            }
+            lk.maze[cur.row as usize][cur.col as usize] |= seen | guide.paint;
+            solve::flush_dark_mini_path_coordinate(&lk.maze, cur);
+        } else {
+            print::maze_panic!("Solve thread panic!");
+        }
+
+        thread::sleep(time::Duration::from_micros(guide.speed));
+
+        // Bias threads towards their original dispatch direction with do-while loop.
+        let mut i = guide.index;
+        for _ in 0..solve::NUM_DIRECTIONS {
+            let p: &maze::Point = &maze::CARDINAL_DIRECTIONS[i];
+            let next = maze::Point {
+                row: cur.row + p.row,
+                col: cur.col + p.col,
+            };
+
+            if match monitor.lock() {
+                Err(p) => print::maze_panic!("Solve thread panic: {}", p),
+                Ok(lk) => {
+                    (lk.maze[next.row as usize][next.col as usize] & seen) == 0
+                        && (lk.maze[next.row as usize][next.col as usize] & maze::PATH_BIT) != 0
+                }
+            } {
+                dfs.push(next);
+                continue 'branching;
+            }
+            i = (i + 1) % solve::NUM_DIRECTIONS;
+        }
+
+        match monitor.lock() {
+            Ok(mut lk) => {
+                lk.maze[cur.row as usize][cur.col as usize] &= !guide.paint;
+                solve::flush_dark_mini_path_coordinate(&lk.maze, cur);
             }
             Err(p) => print::maze_panic!("Solve thread panic!: {}", p),
         }
@@ -279,6 +489,73 @@ fn animated_gatherer(monitor: solve::SolverMonitor, guide: solve::ThreadGuide) {
             Ok(mut lk) => {
                 lk.maze[cur.row as usize][cur.col as usize] &= !guide.paint;
                 solve::flush_cursor_path_coordinate(&lk.maze, cur);
+            }
+            Err(p) => print::maze_panic!("Solve thread panic!: {}", p),
+        }
+        thread::sleep(time::Duration::from_micros(guide.speed));
+        dfs.pop();
+    }
+}
+
+fn animated_mini_gatherer(monitor: solve::SolverMonitor, guide: solve::ThreadGuide) {
+    let seen: solve::ThreadCache = guide.paint << solve::THREAD_TAG_OFFSET;
+    let mut dfs: Vec<maze::Point> = Vec::with_capacity(solve::INITIAL_PATH_LEN);
+    dfs.push(guide.start);
+    'branching: while let Some(&cur) = dfs.last() {
+        if let Ok(mut lk) = monitor.lock() {
+            if lk.maze.exit() {
+                return;
+            }
+            match (
+                (lk.maze[cur.row as usize][cur.col as usize] & solve::FINISH_BIT) != 0,
+                (lk.maze[cur.row as usize][cur.col as usize] & solve::CACHE_MASK) == 0,
+            ) {
+                (true, true) => {
+                    lk.maze[cur.row as usize][cur.col as usize] |= guide.paint | seen;
+                    solve::flush_dark_mini_path_coordinate(&lk.maze, cur);
+                    return;
+                }
+                (true, false) => {
+                    lk.maze[cur.row as usize][cur.col as usize] |= seen;
+                }
+                (_, _) => {
+                    lk.maze[cur.row as usize][cur.col as usize] |= guide.paint | seen;
+                    solve::flush_dark_mini_path_coordinate(&lk.maze, cur);
+                }
+            }
+        } else {
+            print::maze_panic!("Solve thread panic!");
+        }
+
+        thread::sleep(time::Duration::from_micros(guide.speed));
+
+        // Bias threads towards their original dispatch direction with do-while loop.
+        let mut i = guide.index;
+        for _ in 0..solve::NUM_DIRECTIONS {
+            let p: &maze::Point = &maze::CARDINAL_DIRECTIONS[i];
+            let next = maze::Point {
+                row: cur.row + p.row,
+                col: cur.col + p.col,
+            };
+
+            if match monitor.lock() {
+                Err(p) => print::maze_panic!("Solve thread panic: {}", p),
+                Ok(lk) => {
+                    (lk.maze[next.row as usize][next.col as usize] & seen) == 0
+                        && (lk.maze[next.row as usize][next.col as usize] & maze::PATH_BIT) != 0
+                }
+            } {
+                dfs.push(next);
+                continue 'branching;
+            }
+
+            i = (i + 1) % solve::NUM_DIRECTIONS;
+        }
+
+        match monitor.lock() {
+            Ok(mut lk) => {
+                lk.maze[cur.row as usize][cur.col as usize] &= !guide.paint;
+                solve::flush_dark_mini_path_coordinate(&lk.maze, cur);
             }
             Err(p) => print::maze_panic!("Solve thread panic!: {}", p),
         }

--- a/maze_progs/solvers/src/darkfloodfs.rs
+++ b/maze_progs/solvers/src/darkfloodfs.rs
@@ -9,6 +9,15 @@ use std::{thread, time};
 // Public Solver Functions-------------------------------------------------------------------------
 
 pub fn animate_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    if monitor
+        .lock()
+        .unwrap_or_else(|_| print::maze_panic!("Thread panicked"))
+        .maze
+        .is_mini()
+    {
+        animate_mini_hunt(monitor, speed);
+        return;
+    }
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {
@@ -53,7 +62,7 @@ pub fn animate_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
     }
 }
 
-pub fn animate_mini_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
+fn animate_mini_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {
@@ -99,6 +108,15 @@ pub fn animate_mini_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
 }
 
 pub fn animate_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    if monitor
+        .lock()
+        .unwrap_or_else(|_| print::maze_panic!("Thread panicked"))
+        .maze
+        .is_mini()
+    {
+        animate_mini_gather(monitor, speed);
+        return;
+    }
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {
@@ -145,7 +163,7 @@ pub fn animate_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
     }
 }
 
-pub fn animate_mini_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
+fn animate_mini_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {
@@ -193,6 +211,15 @@ pub fn animate_mini_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
 }
 
 pub fn animate_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    if monitor
+        .lock()
+        .unwrap_or_else(|_| print::maze_panic!("Thread panicked"))
+        .maze
+        .is_mini()
+    {
+        animate_mini_corner(monitor, speed);
+        return;
+    }
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let mut corner_starts: [maze::Point; 4] = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {
@@ -252,7 +279,7 @@ pub fn animate_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
     }
 }
 
-pub fn animate_mini_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
+fn animate_mini_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let mut corner_starts: [maze::Point; 4] = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {

--- a/maze_progs/solvers/src/darkfloodfs.rs
+++ b/maze_progs/solvers/src/darkfloodfs.rs
@@ -53,6 +53,51 @@ pub fn animate_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
     }
 }
 
+pub fn animate_mini_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    let animation = solve::SOLVER_SPEEDS[speed as usize];
+    let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
+        if lk.maze.exit() {
+            return;
+        }
+        solve::deluminate_maze(&lk.maze);
+        let all_start = solve::pick_random_point(&lk.maze);
+        lk.maze[all_start.row as usize][all_start.col as usize] |= solve::START_BIT;
+        let finish: maze::Point = solve::pick_random_point(&lk.maze);
+        lk.maze[finish.row as usize][finish.col as usize] |= solve::FINISH_BIT;
+        all_start
+    } else {
+        print::maze_panic!("Thread panick.");
+    };
+
+    let mut handles = Vec::with_capacity(solve::NUM_THREADS - 1);
+    for (i_thread, &mask) in solve::THREAD_MASKS.iter().skip(1).enumerate() {
+        let mc = monitor.clone();
+        handles.push(thread::spawn(move || {
+            animated_mini_hunter(
+                mc,
+                solve::ThreadGuide {
+                    index: i_thread + 1,
+                    paint: mask,
+                    start: all_start,
+                    speed: animation,
+                },
+            );
+        }));
+    }
+    animated_mini_hunter(
+        monitor.clone(),
+        solve::ThreadGuide {
+            index: 0,
+            paint: solve::THREAD_MASKS[0],
+            start: all_start,
+            speed: animation,
+        },
+    );
+    for handle in handles {
+        handle.join().unwrap();
+    }
+}
+
 pub fn animate_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
@@ -87,6 +132,53 @@ pub fn animate_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
         }));
     }
     animated_gatherer(
+        monitor.clone(),
+        solve::ThreadGuide {
+            index: 0,
+            paint: solve::THREAD_MASKS[0],
+            start: all_start,
+            speed: animation,
+        },
+    );
+    for handle in handles {
+        handle.join().unwrap();
+    }
+}
+
+pub fn animate_mini_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    let animation = solve::SOLVER_SPEEDS[speed as usize];
+    let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
+        if lk.maze.exit() {
+            return;
+        }
+        solve::deluminate_maze(&lk.maze);
+        let all_start = solve::pick_random_point(&lk.maze);
+        lk.maze[all_start.row as usize][all_start.col as usize] |= solve::START_BIT;
+        for _ in 0..solve::NUM_GATHER_FINISHES {
+            let finish: maze::Point = solve::pick_random_point(&lk.maze);
+            lk.maze[finish.row as usize][finish.col as usize] |= solve::FINISH_BIT;
+        }
+        all_start
+    } else {
+        print::maze_panic!("Thread panic.");
+    };
+
+    let mut handles = Vec::with_capacity(solve::NUM_THREADS - 1);
+    for (i_thread, &mask) in solve::THREAD_MASKS.iter().skip(1).enumerate() {
+        let mc = monitor.clone();
+        handles.push(thread::spawn(move || {
+            animated_mini_gatherer(
+                mc,
+                solve::ThreadGuide {
+                    index: i_thread + 1,
+                    paint: mask,
+                    start: all_start,
+                    speed: animation,
+                },
+            );
+        }));
+    }
+    animated_mini_gatherer(
         monitor.clone(),
         solve::ThreadGuide {
             index: 0,
@@ -160,6 +252,66 @@ pub fn animate_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
     }
 }
 
+pub fn animate_mini_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    let animation = solve::SOLVER_SPEEDS[speed as usize];
+    let mut corner_starts: [maze::Point; 4] = if let Ok(mut lk) = monitor.lock() {
+        if lk.maze.exit() {
+            return;
+        }
+        solve::deluminate_maze(&lk.maze);
+        let corner_starts = solve::set_corner_starts(&lk.maze);
+        for p in corner_starts {
+            lk.maze[p.row as usize][p.col as usize] |= solve::START_BIT;
+        }
+
+        let finish = maze::Point {
+            row: lk.maze.row_size() / 2,
+            col: lk.maze.col_size() / 2,
+        };
+        for d in maze::ALL_DIRECTIONS {
+            let next = maze::Point {
+                row: finish.row + d.row,
+                col: finish.col + d.col,
+            };
+            lk.maze[next.row as usize][next.col as usize] |= maze::PATH_BIT;
+        }
+        lk.maze[finish.row as usize][finish.col as usize] |= maze::PATH_BIT;
+        lk.maze[finish.row as usize][finish.col as usize] |= solve::FINISH_BIT;
+        corner_starts
+    } else {
+        print::maze_panic!("Thread panic.");
+    };
+
+    corner_starts.shuffle(&mut thread_rng());
+    let mut handles = Vec::with_capacity(solve::NUM_THREADS - 1);
+    for (i_thread, &mask) in solve::THREAD_MASKS.iter().skip(1).enumerate() {
+        let mc = monitor.clone();
+        handles.push(thread::spawn(move || {
+            animated_mini_hunter(
+                mc,
+                solve::ThreadGuide {
+                    index: i_thread + 1,
+                    paint: mask,
+                    start: corner_starts[i_thread + 1],
+                    speed: animation,
+                },
+            );
+        }));
+    }
+    animated_mini_hunter(
+        monitor.clone(),
+        solve::ThreadGuide {
+            index: 0,
+            paint: solve::THREAD_MASKS[0],
+            start: corner_starts[0],
+            speed: animation,
+        },
+    );
+    for handle in handles {
+        handle.join().unwrap();
+    }
+}
+
 // Dispatch Functions for each Thread--------------------------------------------------------------
 
 fn animated_hunter(monitor: solve::SolverMonitor, guide: solve::ThreadGuide) {
@@ -210,6 +362,54 @@ fn animated_hunter(monitor: solve::SolverMonitor, guide: solve::ThreadGuide) {
     }
 }
 
+fn animated_mini_hunter(monitor: solve::SolverMonitor, guide: solve::ThreadGuide) {
+    let seen: solve::ThreadCache = guide.paint << solve::THREAD_TAG_OFFSET;
+    let mut dfs: Vec<maze::Point> = Vec::with_capacity(solve::INITIAL_PATH_LEN);
+    dfs.push(guide.start);
+    'branching: while let Some(&cur) = dfs.last() {
+        if let Ok(mut lk) = monitor.lock() {
+            if lk.maze.exit() || lk.win.is_some() {
+                return;
+            }
+            if (lk.maze[cur.row as usize][cur.col as usize] & solve::FINISH_BIT) != 0 {
+                lk.maze[cur.row as usize][cur.col as usize] |= guide.paint;
+                solve::flush_dark_mini_path_coordinate(&lk.maze, cur);
+                lk.win.get_or_insert(guide.index);
+                return;
+            }
+            lk.maze[cur.row as usize][cur.col as usize] |= seen | guide.paint;
+            solve::flush_dark_mini_path_coordinate(&lk.maze, cur);
+        } else {
+            print::maze_panic!("Solve thread print::maze_panic!");
+        }
+
+        thread::sleep(time::Duration::from_micros(guide.speed));
+
+        // Bias threads towards their original dispatch direction with do-while loop.
+        let mut i = guide.index;
+        for _ in 0..solve::NUM_DIRECTIONS {
+            let p: &maze::Point = &maze::CARDINAL_DIRECTIONS[i];
+            let next = maze::Point {
+                row: cur.row + p.row,
+                col: cur.col + p.col,
+            };
+
+            if match monitor.lock() {
+                Err(p) => print::maze_panic!("Solve thread panic: {}", p),
+                Ok(lk) => {
+                    (lk.maze[next.row as usize][next.col as usize] & seen) == 0
+                        && (lk.maze[next.row as usize][next.col as usize] & maze::PATH_BIT) != 0
+                }
+            } {
+                dfs.push(next);
+                continue 'branching;
+            }
+            i = (i + 1) % solve::NUM_DIRECTIONS;
+        }
+        dfs.pop();
+    }
+}
+
 fn animated_gatherer(monitor: solve::SolverMonitor, guide: solve::ThreadGuide) {
     let seen: solve::ThreadCache = guide.paint << solve::THREAD_TAG_OFFSET;
     let mut dfs: Vec<maze::Point> = Vec::with_capacity(solve::INITIAL_PATH_LEN);
@@ -228,6 +428,55 @@ fn animated_gatherer(monitor: solve::SolverMonitor, guide: solve::ThreadGuide) {
             }
             lk.maze[cur.row as usize][cur.col as usize] |= seen | guide.paint;
             solve::flush_cursor_path_coordinate(&lk.maze, cur);
+        } else {
+            print::maze_panic!("Solve thread print::maze_panic!");
+        }
+
+        thread::sleep(time::Duration::from_micros(guide.speed));
+
+        // Bias threads towards their original dispatch direction with do-while loop.
+        let mut i = guide.index;
+        for _ in 0..solve::NUM_DIRECTIONS {
+            let p: &maze::Point = &maze::CARDINAL_DIRECTIONS[i];
+            let next = maze::Point {
+                row: cur.row + p.row,
+                col: cur.col + p.col,
+            };
+
+            if match monitor.lock() {
+                Err(p) => print::maze_panic!("Solve thread panic: {}", p),
+                Ok(lk) => {
+                    (lk.maze[next.row as usize][next.col as usize] & seen) == 0
+                        && (lk.maze[next.row as usize][next.col as usize] & maze::PATH_BIT) != 0
+                }
+            } {
+                dfs.push(next);
+                continue 'branching;
+            }
+            i = (i + 1) % solve::NUM_DIRECTIONS;
+        }
+        dfs.pop();
+    }
+}
+
+fn animated_mini_gatherer(monitor: solve::SolverMonitor, guide: solve::ThreadGuide) {
+    let seen: solve::ThreadCache = guide.paint << solve::THREAD_TAG_OFFSET;
+    let mut dfs: Vec<maze::Point> = Vec::with_capacity(solve::INITIAL_PATH_LEN);
+    dfs.push(guide.start);
+    'branching: while let Some(&cur) = dfs.last() {
+        if let Ok(mut lk) = monitor.lock() {
+            if lk.maze.exit() {
+                return;
+            }
+            if (lk.maze[cur.row as usize][cur.col as usize] & solve::FINISH_BIT) != 0
+                && (lk.maze[cur.row as usize][cur.col as usize] & solve::CACHE_MASK) == 0
+            {
+                lk.maze[cur.row as usize][cur.col as usize] |= guide.paint | seen;
+                solve::flush_dark_mini_path_coordinate(&lk.maze, cur);
+                return;
+            }
+            lk.maze[cur.row as usize][cur.col as usize] |= seen | guide.paint;
+            solve::flush_dark_mini_path_coordinate(&lk.maze, cur);
         } else {
             print::maze_panic!("Solve thread print::maze_panic!");
         }

--- a/maze_progs/solvers/src/darkrdfs.rs
+++ b/maze_progs/solvers/src/darkrdfs.rs
@@ -53,6 +53,51 @@ pub fn animate_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
     }
 }
 
+pub fn animate_mini_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    let animation = solve::SOLVER_SPEEDS[speed as usize];
+    let all_start = if let Ok(mut lk) = monitor.lock() {
+        if lk.maze.exit() {
+            return;
+        }
+        solve::deluminate_maze(&lk.maze);
+        let all_start = solve::pick_random_point(&lk.maze);
+        lk.maze[all_start.row as usize][all_start.col as usize] |= solve::START_BIT;
+        let finish: maze::Point = solve::pick_random_point(&lk.maze);
+        lk.maze[finish.row as usize][finish.col as usize] |= solve::FINISH_BIT;
+        all_start
+    } else {
+        print::maze_panic!("Thread panic.");
+    };
+
+    let mut handles = Vec::with_capacity(solve::NUM_THREADS - 1);
+    for (i_thread, &mask) in solve::THREAD_MASKS.iter().skip(1).enumerate() {
+        let mc = monitor.clone();
+        handles.push(thread::spawn(move || {
+            animated_mini_hunter(
+                mc,
+                solve::ThreadGuide {
+                    index: i_thread + 1,
+                    paint: mask,
+                    start: all_start,
+                    speed: animation,
+                },
+            );
+        }));
+    }
+    animated_mini_hunter(
+        monitor.clone(),
+        solve::ThreadGuide {
+            index: 0,
+            paint: solve::THREAD_MASKS[0],
+            start: all_start,
+            speed: animation,
+        },
+    );
+    for handle in handles {
+        handle.join().unwrap();
+    }
+}
+
 pub fn animate_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
@@ -87,6 +132,53 @@ pub fn animate_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
         }));
     }
     animated_gatherer(
+        monitor.clone(),
+        solve::ThreadGuide {
+            index: 0,
+            paint: solve::THREAD_MASKS[0],
+            start: all_start,
+            speed: animation,
+        },
+    );
+    for handle in handles {
+        handle.join().unwrap();
+    }
+}
+
+pub fn animate_mini_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    let animation = solve::SOLVER_SPEEDS[speed as usize];
+    let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
+        if lk.maze.exit() {
+            return;
+        }
+        solve::deluminate_maze(&lk.maze);
+        let all_start = solve::pick_random_point(&lk.maze);
+        lk.maze[all_start.row as usize][all_start.col as usize] |= solve::START_BIT;
+        for _ in 0..solve::NUM_GATHER_FINISHES {
+            let finish: maze::Point = solve::pick_random_point(&lk.maze);
+            lk.maze[finish.row as usize][finish.col as usize] |= solve::FINISH_BIT;
+        }
+        all_start
+    } else {
+        print::maze_panic!("Thread panic.");
+    };
+
+    let mut handles = Vec::with_capacity(solve::NUM_THREADS - 1);
+    for (i_thread, &mask) in solve::THREAD_MASKS.iter().skip(1).enumerate() {
+        let mc = monitor.clone();
+        handles.push(thread::spawn(move || {
+            animated_mini_gatherer(
+                mc,
+                solve::ThreadGuide {
+                    index: i_thread + 1,
+                    paint: mask,
+                    start: all_start,
+                    speed: animation,
+                },
+            );
+        }));
+    }
+    animated_mini_gatherer(
         monitor.clone(),
         solve::ThreadGuide {
             index: 0,
@@ -146,6 +238,65 @@ pub fn animate_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
         }));
     }
     animated_hunter(
+        monitor.clone(),
+        solve::ThreadGuide {
+            index: 0,
+            paint: solve::THREAD_MASKS[0],
+            start: corner_starts[0],
+            speed: animation,
+        },
+    );
+    for handle in handles {
+        handle.join().unwrap();
+    }
+}
+
+pub fn animate_mini_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    let animation = solve::SOLVER_SPEEDS[speed as usize];
+    let mut corner_starts: [maze::Point; 4] = if let Ok(mut lk) = monitor.lock() {
+        if lk.maze.exit() {
+            return;
+        }
+        solve::deluminate_maze(&lk.maze);
+        let corner_starts = solve::set_corner_starts(&lk.maze);
+        for p in corner_starts {
+            lk.maze[p.row as usize][p.col as usize] |= solve::START_BIT;
+        }
+        let finish = maze::Point {
+            row: lk.maze.row_size() / 2,
+            col: lk.maze.col_size() / 2,
+        };
+        for d in maze::ALL_DIRECTIONS {
+            let next = maze::Point {
+                row: finish.row + d.row,
+                col: finish.col + d.col,
+            };
+            lk.maze[next.row as usize][next.col as usize] |= maze::PATH_BIT;
+        }
+        lk.maze[finish.row as usize][finish.col as usize] |= maze::PATH_BIT;
+        lk.maze[finish.row as usize][finish.col as usize] |= solve::FINISH_BIT;
+        corner_starts
+    } else {
+        print::maze_panic!("Thread panic.");
+    };
+
+    corner_starts.shuffle(&mut thread_rng());
+    let mut handles = Vec::with_capacity(solve::NUM_THREADS - 1);
+    for (i_thread, &mask) in solve::THREAD_MASKS.iter().skip(1).enumerate() {
+        let mc = monitor.clone();
+        handles.push(thread::spawn(move || {
+            animated_mini_hunter(
+                mc,
+                solve::ThreadGuide {
+                    index: i_thread + 1,
+                    paint: mask,
+                    start: corner_starts[i_thread + 1],
+                    speed: animation,
+                },
+            );
+        }));
+    }
+    animated_mini_hunter(
         monitor.clone(),
         solve::ThreadGuide {
             index: 0,
@@ -219,6 +370,64 @@ fn animated_hunter(monitor: solve::SolverMonitor, guide: solve::ThreadGuide) {
     }
 }
 
+fn animated_mini_hunter(monitor: solve::SolverMonitor, guide: solve::ThreadGuide) {
+    let seen: solve::ThreadCache = guide.paint << solve::THREAD_TAG_OFFSET;
+    let mut dfs: Vec<maze::Point> = Vec::with_capacity(solve::INITIAL_PATH_LEN);
+    dfs.push(guide.start);
+    let mut rng = thread_rng();
+    let mut rng_arr: Vec<usize> = (0..solve::NUM_DIRECTIONS).collect();
+    'branching: while let Some(&cur) = dfs.last() {
+        if let Ok(mut lk) = monitor.lock() {
+            if lk.maze.exit() || lk.win.is_some() {
+                return;
+            }
+            if (lk.maze[cur.row as usize][cur.col as usize] & solve::FINISH_BIT) != 0 {
+                lk.win.get_or_insert(guide.index);
+                lk.maze[cur.row as usize][cur.col as usize] |= guide.paint;
+                solve::flush_dark_mini_path_coordinate(&lk.maze, cur);
+                return;
+            }
+            lk.maze[cur.row as usize][cur.col as usize] |= seen | guide.paint;
+            solve::flush_dark_mini_path_coordinate(&lk.maze, cur);
+        } else {
+            print::maze_panic!("Solve thread panic!");
+        }
+
+        thread::sleep(time::Duration::from_micros(guide.speed));
+
+        // Bias threads towards their original dispatch direction with do-while loop.
+        rng_arr.shuffle(&mut rng);
+        for &i in &rng_arr {
+            let p: &maze::Point = &maze::CARDINAL_DIRECTIONS[i];
+            let next = maze::Point {
+                row: cur.row + p.row,
+                col: cur.col + p.col,
+            };
+
+            if match monitor.lock() {
+                Ok(lk) => {
+                    (lk.maze[next.row as usize][next.col as usize] & seen) == 0
+                        && (lk.maze[next.row as usize][next.col as usize] & maze::PATH_BIT) != 0
+                }
+                Err(p) => print::maze_panic!("Solve thread panic: {}", p),
+            } {
+                dfs.push(next);
+                continue 'branching;
+            }
+        }
+
+        match monitor.lock() {
+            Ok(mut lk) => {
+                lk.maze[cur.row as usize][cur.col as usize] &= !guide.paint;
+                solve::flush_dark_mini_path_coordinate(&lk.maze, cur);
+            }
+            Err(p) => print::maze_panic!("Solve thread panic!: {}", p),
+        }
+        thread::sleep(time::Duration::from_micros(guide.speed));
+        dfs.pop();
+    }
+}
+
 fn animated_gatherer(monitor: solve::SolverMonitor, guide: solve::ThreadGuide) {
     let seen: solve::ThreadCache = guide.paint << solve::THREAD_TAG_OFFSET;
     let mut dfs: Vec<maze::Point> = Vec::with_capacity(solve::INITIAL_PATH_LEN);
@@ -270,6 +479,65 @@ fn animated_gatherer(monitor: solve::SolverMonitor, guide: solve::ThreadGuide) {
             Ok(mut lk) => {
                 lk.maze[cur.row as usize][cur.col as usize] &= !guide.paint;
                 solve::flush_cursor_path_coordinate(&lk.maze, cur);
+            }
+            Err(p) => print::maze_panic!("Solve thread panic!: {}", p),
+        };
+        thread::sleep(time::Duration::from_micros(guide.speed));
+        dfs.pop();
+    }
+}
+
+fn animated_mini_gatherer(monitor: solve::SolverMonitor, guide: solve::ThreadGuide) {
+    let seen: solve::ThreadCache = guide.paint << solve::THREAD_TAG_OFFSET;
+    let mut dfs: Vec<maze::Point> = Vec::with_capacity(solve::INITIAL_PATH_LEN);
+    dfs.push(guide.start);
+    let mut rng = thread_rng();
+    let mut rng_arr: Vec<usize> = (0..solve::NUM_DIRECTIONS).collect();
+    'branching: while let Some(&cur) = dfs.last() {
+        if let Ok(mut lk) = monitor.lock() {
+            if lk.maze.exit() {
+                return;
+            }
+            if (lk.maze[cur.row as usize][cur.col as usize] & solve::FINISH_BIT) != 0
+                && (lk.maze[cur.row as usize][cur.col as usize] & solve::CACHE_MASK) == 0
+            {
+                lk.maze[cur.row as usize][cur.col as usize] |= seen | guide.paint;
+                solve::flush_dark_mini_path_coordinate(&lk.maze, cur);
+                return;
+            }
+            lk.maze[cur.row as usize][cur.col as usize] |= seen | guide.paint;
+            solve::flush_dark_mini_path_coordinate(&lk.maze, cur);
+        } else {
+            print::maze_panic!("Solve thread panic!");
+        }
+
+        thread::sleep(time::Duration::from_micros(guide.speed));
+
+        // Bias threads towards their original dispatch direction with do-while loop.
+        rng_arr.shuffle(&mut rng);
+        for &i in &rng_arr {
+            let p: &maze::Point = &maze::CARDINAL_DIRECTIONS[i];
+            let next = maze::Point {
+                row: cur.row + p.row,
+                col: cur.col + p.col,
+            };
+
+            if match monitor.lock() {
+                Ok(lk) => {
+                    (lk.maze[next.row as usize][next.col as usize] & seen) == 0
+                        && (lk.maze[next.row as usize][next.col as usize] & maze::PATH_BIT) != 0
+                }
+                Err(p) => print::maze_panic!("Solve thread panic: {}", p),
+            } {
+                dfs.push(next);
+                continue 'branching;
+            }
+        }
+
+        match monitor.lock() {
+            Ok(mut lk) => {
+                lk.maze[cur.row as usize][cur.col as usize] &= !guide.paint;
+                solve::flush_dark_mini_path_coordinate(&lk.maze, cur);
             }
             Err(p) => print::maze_panic!("Solve thread panic!: {}", p),
         };

--- a/maze_progs/solvers/src/darkrdfs.rs
+++ b/maze_progs/solvers/src/darkrdfs.rs
@@ -9,6 +9,15 @@ use std::{thread, time};
 // Public Solver Functions-------------------------------------------------------------------------
 
 pub fn animate_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    if monitor
+        .lock()
+        .unwrap_or_else(|_| print::maze_panic!("Thread panicked"))
+        .maze
+        .is_mini()
+    {
+        animate_mini_hunt(monitor, speed);
+        return;
+    }
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let all_start = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {
@@ -53,7 +62,7 @@ pub fn animate_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
     }
 }
 
-pub fn animate_mini_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
+fn animate_mini_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let all_start = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {
@@ -99,6 +108,15 @@ pub fn animate_mini_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
 }
 
 pub fn animate_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    if monitor
+        .lock()
+        .unwrap_or_else(|_| print::maze_panic!("Thread panicked"))
+        .maze
+        .is_mini()
+    {
+        animate_mini_gather(monitor, speed);
+        return;
+    }
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {
@@ -145,7 +163,7 @@ pub fn animate_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
     }
 }
 
-pub fn animate_mini_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
+fn animate_mini_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {
@@ -193,6 +211,15 @@ pub fn animate_mini_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
 }
 
 pub fn animate_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    if monitor
+        .lock()
+        .unwrap_or_else(|_| print::maze_panic!("Thread panicked"))
+        .maze
+        .is_mini()
+    {
+        animate_mini_corner(monitor, speed);
+        return;
+    }
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let mut corner_starts: [maze::Point; 4] = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {
@@ -251,7 +278,7 @@ pub fn animate_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
     }
 }
 
-pub fn animate_mini_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
+fn animate_mini_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let mut corner_starts: [maze::Point; 4] = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {

--- a/maze_progs/solvers/src/dfs.rs
+++ b/maze_progs/solvers/src/dfs.rs
@@ -206,6 +206,52 @@ pub fn animate_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
     }
 }
 
+pub fn animate_mini_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    let animation = solve::SOLVER_SPEEDS[speed as usize];
+    let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
+        if lk.maze.exit() {
+            return;
+        }
+        let all_start = solve::pick_random_point(&lk.maze);
+        lk.maze[all_start.row as usize][all_start.col as usize] |= solve::START_BIT;
+        let finish: maze::Point = solve::pick_random_point(&lk.maze);
+        lk.maze[finish.row as usize][finish.col as usize] |= solve::FINISH_BIT;
+        solve::flush_mini_path_coordinate(&lk.maze, finish);
+        thread::sleep(time::Duration::from_micros(animation));
+        all_start
+    } else {
+        print::maze_panic!("Thread panic.");
+    };
+
+    let mut handles = Vec::with_capacity(solve::NUM_THREADS - 1);
+    for (i_thread, &mask) in solve::THREAD_MASKS.iter().skip(1).enumerate() {
+        let mc = monitor.clone();
+        handles.push(thread::spawn(move || {
+            animated_mini_hunter(
+                mc,
+                solve::ThreadGuide {
+                    index: i_thread + 1,
+                    paint: mask,
+                    start: all_start,
+                    speed: animation,
+                },
+            );
+        }));
+    }
+    animated_mini_hunter(
+        monitor.clone(),
+        solve::ThreadGuide {
+            index: 0,
+            paint: solve::THREAD_MASKS[0],
+            start: all_start,
+            speed: animation,
+        },
+    );
+    for handle in handles {
+        handle.join().unwrap();
+    }
+}
+
 pub fn animate_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
@@ -423,6 +469,63 @@ fn animated_hunter(monitor: solve::SolverMonitor, guide: solve::ThreadGuide) {
             Ok(mut lk) => {
                 lk.maze[cur.row as usize][cur.col as usize] &= !guide.paint;
                 solve::flush_cursor_path_coordinate(&lk.maze, cur);
+            }
+            Err(p) => print::maze_panic!("Solve thread panic!: {}", p),
+        }
+        thread::sleep(time::Duration::from_micros(guide.speed));
+        dfs.pop();
+    }
+}
+
+fn animated_mini_hunter(monitor: solve::SolverMonitor, guide: solve::ThreadGuide) {
+    let seen: solve::ThreadCache = guide.paint << solve::THREAD_TAG_OFFSET;
+    let mut dfs: Vec<maze::Point> = Vec::with_capacity(solve::INITIAL_PATH_LEN);
+    dfs.push(guide.start);
+    'branching: while let Some(&cur) = dfs.last() {
+        if let Ok(mut lk) = monitor.lock() {
+            if lk.maze.exit() || lk.win.is_some() {
+                return;
+            }
+            if (lk.maze[cur.row as usize][cur.col as usize] & solve::FINISH_BIT) != 0 {
+                lk.maze[cur.row as usize][cur.col as usize] |= guide.paint;
+                solve::flush_mini_path_coordinate(&lk.maze, cur);
+                lk.win.get_or_insert(guide.index);
+                return;
+            }
+            lk.maze[cur.row as usize][cur.col as usize] |= seen | guide.paint;
+            solve::flush_mini_path_coordinate(&lk.maze, cur);
+        } else {
+            print::maze_panic!("Solve thread panic!");
+        }
+
+        thread::sleep(time::Duration::from_micros(guide.speed));
+
+        // Bias threads towards their original dispatch direction with do-while loop.
+        let mut i = guide.index;
+        for _ in 0..solve::NUM_DIRECTIONS {
+            let p: &maze::Point = &maze::CARDINAL_DIRECTIONS[i];
+            let next = maze::Point {
+                row: cur.row + p.row,
+                col: cur.col + p.col,
+            };
+
+            if match monitor.lock() {
+                Err(p) => print::maze_panic!("Solve thread panic: {}", p),
+                Ok(lk) => {
+                    (lk.maze[next.row as usize][next.col as usize] & seen) == 0
+                        && (lk.maze[next.row as usize][next.col as usize] & maze::PATH_BIT) != 0
+                }
+            } {
+                dfs.push(next);
+                continue 'branching;
+            }
+            i = (i + 1) % solve::NUM_DIRECTIONS;
+        }
+
+        match monitor.lock() {
+            Ok(mut lk) => {
+                lk.maze[cur.row as usize][cur.col as usize] &= !guide.paint;
+                solve::flush_mini_path_coordinate(&lk.maze, cur);
             }
             Err(p) => print::maze_panic!("Solve thread panic!: {}", p),
         }

--- a/maze_progs/solvers/src/dfs.rs
+++ b/maze_progs/solvers/src/dfs.rs
@@ -161,6 +161,15 @@ pub fn corner(monitor: solve::SolverMonitor) {
 }
 
 pub fn animate_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    if monitor
+        .lock()
+        .unwrap_or_else(|_| print::maze_panic!("Thread panicked"))
+        .maze
+        .is_mini()
+    {
+        animate_mini_hunt(monitor, speed);
+        return;
+    }
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {
@@ -206,7 +215,7 @@ pub fn animate_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
     }
 }
 
-pub fn animate_mini_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
+fn animate_mini_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {
@@ -253,6 +262,15 @@ pub fn animate_mini_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
 }
 
 pub fn animate_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    if monitor
+        .lock()
+        .unwrap_or_else(|_| print::maze_panic!("Thread panicked"))
+        .maze
+        .is_mini()
+    {
+        animate_mini_gather(monitor, speed);
+        return;
+    }
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {
@@ -300,7 +318,7 @@ pub fn animate_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
     }
 }
 
-pub fn animate_mini_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
+fn animate_mini_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {
@@ -349,6 +367,15 @@ pub fn animate_mini_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
 }
 
 pub fn animate_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    if monitor
+        .lock()
+        .unwrap_or_else(|_| print::maze_panic!("Thread panicked"))
+        .maze
+        .is_mini()
+    {
+        animate_mini_corner(monitor, speed);
+        return;
+    }
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let mut corner_starts: [maze::Point; 4] = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {
@@ -413,7 +440,7 @@ pub fn animate_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
     }
 }
 
-pub fn animate_mini_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
+fn animate_mini_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let mut corner_starts: [maze::Point; 4] = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {

--- a/maze_progs/solvers/src/dfs.rs
+++ b/maze_progs/solvers/src/dfs.rs
@@ -300,6 +300,54 @@ pub fn animate_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
     }
 }
 
+pub fn animate_mini_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    let animation = solve::SOLVER_SPEEDS[speed as usize];
+    let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
+        if lk.maze.exit() {
+            return;
+        }
+        let all_start = solve::pick_random_point(&lk.maze);
+        lk.maze[all_start.row as usize][all_start.col as usize] |= solve::START_BIT;
+        for _ in 0..solve::NUM_GATHER_FINISHES {
+            let finish: maze::Point = solve::pick_random_point(&lk.maze);
+            lk.maze[finish.row as usize][finish.col as usize] |= solve::FINISH_BIT;
+            solve::flush_mini_path_coordinate(&lk.maze, finish);
+            thread::sleep(time::Duration::from_micros(animation));
+        }
+        all_start
+    } else {
+        print::maze_panic!("Thread panic.");
+    };
+
+    let mut handles = Vec::with_capacity(solve::NUM_THREADS - 1);
+    for (i_thread, &mask) in solve::THREAD_MASKS.iter().skip(1).enumerate() {
+        let mc = monitor.clone();
+        handles.push(thread::spawn(move || {
+            animated_mini_gatherer(
+                mc,
+                solve::ThreadGuide {
+                    index: i_thread + 1,
+                    paint: mask,
+                    start: all_start,
+                    speed: animation,
+                },
+            );
+        }));
+    }
+    animated_mini_gatherer(
+        monitor.clone(),
+        solve::ThreadGuide {
+            index: 0,
+            paint: solve::THREAD_MASKS[0],
+            start: all_start,
+            speed: animation,
+        },
+    );
+    for handle in handles {
+        handle.join().unwrap();
+    }
+}
+
 pub fn animate_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let mut corner_starts: [maze::Point; 4] = if let Ok(mut lk) = monitor.lock() {
@@ -352,6 +400,71 @@ pub fn animate_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
         }));
     }
     animated_hunter(
+        monitor.clone(),
+        solve::ThreadGuide {
+            index: 0,
+            paint: solve::THREAD_MASKS[0],
+            start: corner_starts[0],
+            speed: animation,
+        },
+    );
+    for handle in handles {
+        handle.join().unwrap();
+    }
+}
+
+pub fn animate_mini_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    let animation = solve::SOLVER_SPEEDS[speed as usize];
+    let mut corner_starts: [maze::Point; 4] = if let Ok(mut lk) = monitor.lock() {
+        if lk.maze.exit() {
+            return;
+        }
+        let corner_starts = solve::set_corner_starts(&lk.maze);
+        for p in corner_starts {
+            lk.maze[p.row as usize][p.col as usize] |= solve::START_BIT;
+            solve::flush_mini_path_coordinate(&lk.maze, p);
+            thread::sleep(time::Duration::from_micros(animation));
+        }
+
+        let finish = maze::Point {
+            row: lk.maze.row_size() / 2,
+            col: lk.maze.col_size() / 2,
+        };
+        for d in maze::ALL_DIRECTIONS {
+            let next = maze::Point {
+                row: finish.row + d.row,
+                col: finish.col + d.col,
+            };
+            lk.maze[next.row as usize][next.col as usize] |= maze::PATH_BIT;
+            solve::flush_mini_path_coordinate(&lk.maze, next);
+            thread::sleep(time::Duration::from_micros(animation));
+        }
+        lk.maze[finish.row as usize][finish.col as usize] |= maze::PATH_BIT;
+        lk.maze[finish.row as usize][finish.col as usize] |= solve::FINISH_BIT;
+        solve::flush_mini_path_coordinate(&lk.maze, finish);
+        thread::sleep(time::Duration::from_micros(animation));
+        corner_starts
+    } else {
+        print::maze_panic!("Thread panic.");
+    };
+
+    corner_starts.shuffle(&mut thread_rng());
+    let mut handles = Vec::with_capacity(solve::NUM_THREADS - 1);
+    for (i_thread, &mask) in solve::THREAD_MASKS.iter().skip(1).enumerate() {
+        let mc = monitor.clone();
+        handles.push(thread::spawn(move || {
+            animated_mini_hunter(
+                mc,
+                solve::ThreadGuide {
+                    index: i_thread + 1,
+                    paint: mask,
+                    start: corner_starts[i_thread + 1],
+                    speed: animation,
+                },
+            );
+        }));
+    }
+    animated_mini_hunter(
         monitor.clone(),
         solve::ThreadGuide {
             index: 0,
@@ -646,6 +759,72 @@ fn animated_gatherer(monitor: solve::SolverMonitor, guide: solve::ThreadGuide) {
             Ok(mut lk) => {
                 lk.maze[cur.row as usize][cur.col as usize] &= !guide.paint;
                 solve::flush_cursor_path_coordinate(&lk.maze, cur);
+            }
+            Err(p) => print::maze_panic!("Solve thread panic!: {}", p),
+        }
+        thread::sleep(time::Duration::from_micros(guide.speed));
+        dfs.pop();
+    }
+}
+
+fn animated_mini_gatherer(monitor: solve::SolverMonitor, guide: solve::ThreadGuide) {
+    let seen: solve::ThreadCache = guide.paint << solve::THREAD_TAG_OFFSET;
+    let mut dfs: Vec<maze::Point> = Vec::with_capacity(solve::INITIAL_PATH_LEN);
+    dfs.push(guide.start);
+    'branching: while let Some(&cur) = dfs.last() {
+        if let Ok(mut lk) = monitor.lock() {
+            if lk.maze.exit() {
+                return;
+            }
+            match (
+                (lk.maze[cur.row as usize][cur.col as usize] & solve::FINISH_BIT) != 0,
+                (lk.maze[cur.row as usize][cur.col as usize] & solve::CACHE_MASK) == 0,
+            ) {
+                (true, true) => {
+                    lk.maze[cur.row as usize][cur.col as usize] |= guide.paint | seen;
+                    solve::flush_mini_path_coordinate(&lk.maze, cur);
+                    return;
+                }
+                (true, false) => {
+                    lk.maze[cur.row as usize][cur.col as usize] |= seen;
+                }
+                (_, _) => {
+                    lk.maze[cur.row as usize][cur.col as usize] |= guide.paint | seen;
+                    solve::flush_mini_path_coordinate(&lk.maze, cur);
+                }
+            }
+        } else {
+            print::maze_panic!("Solve thread panic!");
+        }
+
+        thread::sleep(time::Duration::from_micros(guide.speed));
+
+        // Bias threads towards their original dispatch direction with do-while loop.
+        let mut i = guide.index;
+        for _ in 0..solve::NUM_DIRECTIONS {
+            let p: &maze::Point = &maze::CARDINAL_DIRECTIONS[i];
+            let next = maze::Point {
+                row: cur.row + p.row,
+                col: cur.col + p.col,
+            };
+
+            if match monitor.lock() {
+                Err(p) => print::maze_panic!("Solve thread panic: {}", p),
+                Ok(lk) => {
+                    (lk.maze[next.row as usize][next.col as usize] & seen) == 0
+                        && (lk.maze[next.row as usize][next.col as usize] & maze::PATH_BIT) != 0
+                }
+            } {
+                dfs.push(next);
+                continue 'branching;
+            }
+            i = (i + 1) % solve::NUM_DIRECTIONS;
+        }
+
+        match monitor.lock() {
+            Ok(mut lk) => {
+                lk.maze[cur.row as usize][cur.col as usize] &= !guide.paint;
+                solve::flush_mini_path_coordinate(&lk.maze, cur);
             }
             Err(p) => print::maze_panic!("Solve thread panic!: {}", p),
         }

--- a/maze_progs/solvers/src/floodfs.rs
+++ b/maze_progs/solvers/src/floodfs.rs
@@ -160,6 +160,15 @@ pub fn corner(monitor: solve::SolverMonitor) {
 }
 
 pub fn animate_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    if monitor
+        .lock()
+        .unwrap_or_else(|_| print::maze_panic!("Thread panicked"))
+        .maze
+        .is_mini()
+    {
+        animate_mini_hunt(monitor, speed);
+        return;
+    }
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {
@@ -205,7 +214,7 @@ pub fn animate_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
     }
 }
 
-pub fn animate_mini_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
+fn animate_mini_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {
@@ -252,6 +261,15 @@ pub fn animate_mini_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
 }
 
 pub fn animate_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    if monitor
+        .lock()
+        .unwrap_or_else(|_| print::maze_panic!("Thread panicked"))
+        .maze
+        .is_mini()
+    {
+        animate_mini_gather(monitor, speed);
+        return;
+    }
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {
@@ -299,7 +317,7 @@ pub fn animate_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
     }
 }
 
-pub fn animate_mini_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
+fn animate_mini_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {
@@ -348,6 +366,15 @@ pub fn animate_mini_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
 }
 
 pub fn animate_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    if monitor
+        .lock()
+        .unwrap_or_else(|_| print::maze_panic!("Thread panicked"))
+        .maze
+        .is_mini()
+    {
+        animate_mini_corner(monitor, speed);
+        return;
+    }
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let mut corner_starts: [maze::Point; 4] = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {
@@ -412,7 +439,7 @@ pub fn animate_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
     }
 }
 
-pub fn animate_mini_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
+fn animate_mini_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let mut corner_starts: [maze::Point; 4] = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {

--- a/maze_progs/solvers/src/floodfs.rs
+++ b/maze_progs/solvers/src/floodfs.rs
@@ -205,6 +205,52 @@ pub fn animate_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
     }
 }
 
+pub fn animate_mini_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    let animation = solve::SOLVER_SPEEDS[speed as usize];
+    let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
+        if lk.maze.exit() {
+            return;
+        }
+        let all_start = solve::pick_random_point(&lk.maze);
+        lk.maze[all_start.row as usize][all_start.col as usize] |= solve::START_BIT;
+        let finish: maze::Point = solve::pick_random_point(&lk.maze);
+        lk.maze[finish.row as usize][finish.col as usize] |= solve::FINISH_BIT;
+        solve::flush_mini_path_coordinate(&lk.maze, finish);
+        thread::sleep(time::Duration::from_micros(animation));
+        all_start
+    } else {
+        print::maze_panic!("Thread panic.");
+    };
+
+    let mut handles = Vec::with_capacity(solve::NUM_THREADS - 1);
+    for (i_thread, &mask) in solve::THREAD_MASKS.iter().skip(1).enumerate() {
+        let mc = monitor.clone();
+        handles.push(thread::spawn(move || {
+            animated_mini_hunter(
+                mc,
+                solve::ThreadGuide {
+                    index: i_thread + 1,
+                    paint: mask,
+                    start: all_start,
+                    speed: animation,
+                },
+            );
+        }));
+    }
+    animated_mini_hunter(
+        monitor.clone(),
+        solve::ThreadGuide {
+            index: 0,
+            paint: solve::THREAD_MASKS[0],
+            start: all_start,
+            speed: animation,
+        },
+    );
+    for handle in handles {
+        handle.join().unwrap();
+    }
+}
+
 pub fn animate_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
@@ -240,6 +286,54 @@ pub fn animate_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
         }));
     }
     animated_gatherer(
+        monitor.clone(),
+        solve::ThreadGuide {
+            index: 0,
+            paint: solve::THREAD_MASKS[0],
+            start: all_start,
+            speed: animation,
+        },
+    );
+    for handle in handles {
+        handle.join().unwrap();
+    }
+}
+
+pub fn animate_mini_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    let animation = solve::SOLVER_SPEEDS[speed as usize];
+    let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
+        if lk.maze.exit() {
+            return;
+        }
+        let all_start = solve::pick_random_point(&lk.maze);
+        lk.maze[all_start.row as usize][all_start.col as usize] |= solve::START_BIT;
+        for _ in 0..solve::NUM_GATHER_FINISHES {
+            let finish: maze::Point = solve::pick_random_point(&lk.maze);
+            lk.maze[finish.row as usize][finish.col as usize] |= solve::FINISH_BIT;
+            solve::flush_mini_path_coordinate(&lk.maze, finish);
+            thread::sleep(time::Duration::from_micros(animation));
+        }
+        all_start
+    } else {
+        print::maze_panic!("Thread panic.");
+    };
+
+    let mut handles = Vec::with_capacity(solve::NUM_THREADS - 1);
+    for (i_thread, &mask) in solve::THREAD_MASKS.iter().skip(1).enumerate() {
+        let mc = monitor.clone();
+        handles.push(thread::spawn(move || {
+            animated_mini_gatherer(
+                mc,
+                solve::ThreadGuide {
+                    index: i_thread + 1,
+                    paint: mask,
+                    start: all_start,
+                    speed: animation,
+                },
+            );
+        }));
+    }
+    animated_mini_gatherer(
         monitor.clone(),
         solve::ThreadGuide {
             index: 0,
@@ -305,6 +399,71 @@ pub fn animate_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
         }));
     }
     animated_hunter(
+        monitor.clone(),
+        solve::ThreadGuide {
+            index: 0,
+            paint: solve::THREAD_MASKS[0],
+            start: corner_starts[0],
+            speed: animation,
+        },
+    );
+    for handle in handles {
+        handle.join().unwrap();
+    }
+}
+
+pub fn animate_mini_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    let animation = solve::SOLVER_SPEEDS[speed as usize];
+    let mut corner_starts: [maze::Point; 4] = if let Ok(mut lk) = monitor.lock() {
+        if lk.maze.exit() {
+            return;
+        }
+        let corner_starts = solve::set_corner_starts(&lk.maze);
+        for p in corner_starts {
+            lk.maze[p.row as usize][p.col as usize] |= solve::START_BIT;
+            solve::flush_mini_path_coordinate(&lk.maze, p);
+            thread::sleep(time::Duration::from_micros(animation));
+        }
+
+        let finish = maze::Point {
+            row: lk.maze.row_size() / 2,
+            col: lk.maze.col_size() / 2,
+        };
+        for d in maze::ALL_DIRECTIONS {
+            let next = maze::Point {
+                row: finish.row + d.row,
+                col: finish.col + d.col,
+            };
+            lk.maze[next.row as usize][next.col as usize] |= maze::PATH_BIT;
+            solve::flush_mini_path_coordinate(&lk.maze, next);
+            thread::sleep(time::Duration::from_micros(animation));
+        }
+        lk.maze[finish.row as usize][finish.col as usize] |= maze::PATH_BIT;
+        lk.maze[finish.row as usize][finish.col as usize] |= solve::FINISH_BIT;
+        solve::flush_mini_path_coordinate(&lk.maze, finish);
+        thread::sleep(time::Duration::from_micros(animation));
+        corner_starts
+    } else {
+        print::maze_panic!("Thread panic.");
+    };
+
+    corner_starts.shuffle(&mut thread_rng());
+    let mut handles = Vec::with_capacity(solve::NUM_THREADS - 1);
+    for (i_thread, &mask) in solve::THREAD_MASKS.iter().skip(1).enumerate() {
+        let mc = monitor.clone();
+        handles.push(thread::spawn(move || {
+            animated_mini_hunter(
+                mc,
+                solve::ThreadGuide {
+                    index: i_thread + 1,
+                    paint: mask,
+                    start: corner_starts[i_thread + 1],
+                    speed: animation,
+                },
+            );
+        }));
+    }
+    animated_mini_hunter(
         monitor.clone(),
         solve::ThreadGuide {
             index: 0,
@@ -416,6 +575,54 @@ fn animated_hunter(monitor: solve::SolverMonitor, guide: solve::ThreadGuide) {
     }
 }
 
+fn animated_mini_hunter(monitor: solve::SolverMonitor, guide: solve::ThreadGuide) {
+    let seen: solve::ThreadCache = guide.paint << solve::THREAD_TAG_OFFSET;
+    let mut dfs: Vec<maze::Point> = Vec::with_capacity(solve::INITIAL_PATH_LEN);
+    dfs.push(guide.start);
+    'branching: while let Some(&cur) = dfs.last() {
+        if let Ok(mut lk) = monitor.lock() {
+            if lk.maze.exit() || lk.win.is_some() {
+                return;
+            }
+            if (lk.maze[cur.row as usize][cur.col as usize] & solve::FINISH_BIT) != 0 {
+                lk.maze[cur.row as usize][cur.col as usize] |= guide.paint;
+                solve::flush_mini_path_coordinate(&lk.maze, cur);
+                lk.win.get_or_insert(guide.index);
+                return;
+            }
+            lk.maze[cur.row as usize][cur.col as usize] |= seen | guide.paint;
+            solve::flush_mini_path_coordinate(&lk.maze, cur);
+        } else {
+            print::maze_panic!("Solve thread print::maze_panic!");
+        }
+
+        thread::sleep(time::Duration::from_micros(guide.speed));
+
+        // Bias threads towards their original dispatch direction with do-while loop.
+        let mut i = guide.index;
+        for _ in 0..solve::NUM_DIRECTIONS {
+            let p: &maze::Point = &maze::CARDINAL_DIRECTIONS[i];
+            let next = maze::Point {
+                row: cur.row + p.row,
+                col: cur.col + p.col,
+            };
+
+            if match monitor.lock() {
+                Err(p) => print::maze_panic!("Solve thread panic: {}", p),
+                Ok(lk) => {
+                    (lk.maze[next.row as usize][next.col as usize] & seen) == 0
+                        && (lk.maze[next.row as usize][next.col as usize] & maze::PATH_BIT) != 0
+                }
+            } {
+                dfs.push(next);
+                continue 'branching;
+            }
+            i = (i + 1) % solve::NUM_DIRECTIONS;
+        }
+        dfs.pop();
+    }
+}
+
 fn gatherer(monitor: solve::SolverMonitor, guide: solve::ThreadGuide) {
     let seen: solve::ThreadCache = guide.paint << solve::THREAD_TAG_OFFSET;
     let mut dfs: Vec<maze::Point> = Vec::with_capacity(solve::INITIAL_PATH_LEN);
@@ -490,6 +697,63 @@ fn animated_gatherer(monitor: solve::SolverMonitor, guide: solve::ThreadGuide) {
                 (_, _) => {
                     lk.maze[cur.row as usize][cur.col as usize] |= guide.paint | seen;
                     solve::flush_cursor_path_coordinate(&lk.maze, cur);
+                }
+            }
+        } else {
+            print::maze_panic!("Solve thread print::maze_panic!");
+        }
+
+        thread::sleep(time::Duration::from_micros(guide.speed));
+
+        // Bias threads towards their original dispatch direction with do-while loop.
+        let mut i = guide.index;
+        for _ in 0..solve::NUM_DIRECTIONS {
+            let p: &maze::Point = &maze::CARDINAL_DIRECTIONS[i];
+            let next = maze::Point {
+                row: cur.row + p.row,
+                col: cur.col + p.col,
+            };
+
+            if match monitor.lock() {
+                Err(p) => print::maze_panic!("Solve thread panic: {}", p),
+                Ok(lk) => {
+                    (lk.maze[next.row as usize][next.col as usize] & seen) == 0
+                        && (lk.maze[next.row as usize][next.col as usize] & maze::PATH_BIT) != 0
+                }
+            } {
+                dfs.push(next);
+                continue 'branching;
+            }
+            i = (i + 1) % solve::NUM_DIRECTIONS;
+        }
+        dfs.pop();
+    }
+}
+
+fn animated_mini_gatherer(monitor: solve::SolverMonitor, guide: solve::ThreadGuide) {
+    let seen: solve::ThreadCache = guide.paint << solve::THREAD_TAG_OFFSET;
+    let mut dfs: Vec<maze::Point> = Vec::with_capacity(solve::INITIAL_PATH_LEN);
+    dfs.push(guide.start);
+    'branching: while let Some(&cur) = dfs.last() {
+        if let Ok(mut lk) = monitor.lock() {
+            if lk.maze.exit() {
+                return;
+            }
+            match (
+                (lk.maze[cur.row as usize][cur.col as usize] & solve::FINISH_BIT) != 0,
+                (lk.maze[cur.row as usize][cur.col as usize] & solve::CACHE_MASK) == 0,
+            ) {
+                (true, true) => {
+                    lk.maze[cur.row as usize][cur.col as usize] |= guide.paint | seen;
+                    solve::flush_mini_path_coordinate(&lk.maze, cur);
+                    return;
+                }
+                (true, false) => {
+                    lk.maze[cur.row as usize][cur.col as usize] |= seen;
+                }
+                (_, _) => {
+                    lk.maze[cur.row as usize][cur.col as usize] |= guide.paint | seen;
+                    solve::flush_mini_path_coordinate(&lk.maze, cur);
                 }
             }
         } else {

--- a/maze_progs/solvers/src/rdfs.rs
+++ b/maze_progs/solvers/src/rdfs.rs
@@ -161,6 +161,15 @@ pub fn corner(monitor: solve::SolverMonitor) {
 }
 
 pub fn animate_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    if monitor
+        .lock()
+        .unwrap_or_else(|_| print::maze_panic!("Thread panicked"))
+        .maze
+        .is_mini()
+    {
+        animate_mini_hunt(monitor, speed);
+        return;
+    }
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {
@@ -206,7 +215,7 @@ pub fn animate_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
     }
 }
 
-pub fn animate_mini_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
+fn animate_mini_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {
@@ -253,6 +262,15 @@ pub fn animate_mini_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
 }
 
 pub fn animate_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    if monitor
+        .lock()
+        .unwrap_or_else(|_| print::maze_panic!("Thread panicked"))
+        .maze
+        .is_mini()
+    {
+        animate_mini_gather(monitor, speed);
+        return;
+    }
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {
@@ -302,7 +320,7 @@ pub fn animate_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
     }
 }
 
-pub fn animate_mini_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
+fn animate_mini_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {
@@ -353,6 +371,15 @@ pub fn animate_mini_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
 }
 
 pub fn animate_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    if monitor
+        .lock()
+        .unwrap_or_else(|_| print::maze_panic!("Thread panicked"))
+        .maze
+        .is_mini()
+    {
+        animate_mini_corner(monitor, speed);
+        return;
+    }
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let mut corner_starts: [maze::Point; 4] = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {
@@ -417,7 +444,7 @@ pub fn animate_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
     }
 }
 
-pub fn animate_mini_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
+fn animate_mini_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let mut corner_starts: [maze::Point; 4] = if let Ok(mut lk) = monitor.lock() {
         if lk.maze.exit() {

--- a/maze_progs/solvers/src/rdfs.rs
+++ b/maze_progs/solvers/src/rdfs.rs
@@ -206,6 +206,52 @@ pub fn animate_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
     }
 }
 
+pub fn animate_mini_hunt(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    let animation = solve::SOLVER_SPEEDS[speed as usize];
+    let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
+        if lk.maze.exit() {
+            return;
+        }
+        let all_start = solve::pick_random_point(&lk.maze);
+        lk.maze[all_start.row as usize][all_start.col as usize] |= solve::START_BIT;
+        let finish: maze::Point = solve::pick_random_point(&lk.maze);
+        lk.maze[finish.row as usize][finish.col as usize] |= solve::FINISH_BIT;
+        solve::flush_mini_path_coordinate(&lk.maze, finish);
+        thread::sleep(time::Duration::from_micros(animation));
+        all_start
+    } else {
+        print::maze_panic!("Thread panic.");
+    };
+
+    let mut handles = Vec::with_capacity(solve::NUM_THREADS - 1);
+    for (i_thread, &mask) in solve::THREAD_MASKS.iter().skip(1).enumerate() {
+        let monitor_clone = monitor.clone();
+        handles.push(thread::spawn(move || {
+            animated_mini_hunter(
+                monitor_clone,
+                solve::ThreadGuide {
+                    index: i_thread + 1,
+                    paint: mask,
+                    start: all_start,
+                    speed: animation,
+                },
+            );
+        }));
+    }
+    animated_mini_hunter(
+        monitor.clone(),
+        solve::ThreadGuide {
+            index: 0,
+            paint: THREAD_MASKS[0],
+            start: all_start,
+            speed: animation,
+        },
+    );
+    for handle in handles {
+        handle.join().unwrap();
+    }
+}
+
 pub fn animate_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
     let animation = solve::SOLVER_SPEEDS[speed as usize];
     let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
@@ -242,6 +288,56 @@ pub fn animate_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
         }));
     }
     animated_gatherer(
+        monitor,
+        solve::ThreadGuide {
+            index: 0,
+            paint: THREAD_MASKS[0],
+            start: all_start,
+            speed: animation,
+        },
+    );
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+}
+
+pub fn animate_mini_gather(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    let animation = solve::SOLVER_SPEEDS[speed as usize];
+    let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
+        if lk.maze.exit() {
+            return;
+        }
+        let all_start = solve::pick_random_point(&lk.maze);
+        lk.maze[all_start.row as usize][all_start.col as usize] |= solve::START_BIT;
+
+        for _ in 0..solve::NUM_GATHER_FINISHES {
+            let finish: maze::Point = solve::pick_random_point(&lk.maze);
+            lk.maze[finish.row as usize][finish.col as usize] |= solve::FINISH_BIT;
+            solve::flush_mini_path_coordinate(&lk.maze, finish);
+            thread::sleep(time::Duration::from_micros(animation));
+        }
+        all_start
+    } else {
+        print::maze_panic!("Thread panic.");
+    };
+
+    let mut handles = Vec::with_capacity(solve::NUM_THREADS - 1);
+    for (i_thread, &mask) in solve::THREAD_MASKS.iter().skip(1).enumerate() {
+        let monitor_clone = monitor.clone();
+        handles.push(thread::spawn(move || {
+            animated_mini_gatherer(
+                monitor_clone,
+                solve::ThreadGuide {
+                    index: i_thread + 1,
+                    paint: mask,
+                    start: all_start,
+                    speed: animation,
+                },
+            );
+        }));
+    }
+    animated_mini_gatherer(
         monitor,
         solve::ThreadGuide {
             index: 0,
@@ -321,6 +417,70 @@ pub fn animate_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
     }
 }
 
+pub fn animate_mini_corner(monitor: solve::SolverMonitor, speed: speed::Speed) {
+    let animation = solve::SOLVER_SPEEDS[speed as usize];
+    let mut corner_starts: [maze::Point; 4] = if let Ok(mut lk) = monitor.lock() {
+        if lk.maze.exit() {
+            return;
+        }
+        let corner_starts = solve::set_corner_starts(&lk.maze);
+        for p in corner_starts {
+            lk.maze[p.row as usize][p.col as usize] |= solve::START_BIT;
+            solve::flush_mini_path_coordinate(&lk.maze, p);
+            thread::sleep(time::Duration::from_micros(animation));
+        }
+
+        let finish = maze::Point {
+            row: lk.maze.row_size() / 2,
+            col: lk.maze.col_size() / 2,
+        };
+        for d in maze::ALL_DIRECTIONS {
+            let next = maze::Point {
+                row: finish.row + d.row,
+                col: finish.col + d.col,
+            };
+            lk.maze[next.row as usize][next.col as usize] |= maze::PATH_BIT;
+            solve::flush_mini_path_coordinate(&lk.maze, next);
+            thread::sleep(time::Duration::from_micros(animation));
+        }
+        lk.maze[finish.row as usize][finish.col as usize] |= maze::PATH_BIT;
+        lk.maze[finish.row as usize][finish.col as usize] |= solve::FINISH_BIT;
+        solve::flush_mini_path_coordinate(&lk.maze, finish);
+        thread::sleep(time::Duration::from_micros(animation));
+        corner_starts
+    } else {
+        print::maze_panic!("Thread panic.");
+    };
+
+    corner_starts.shuffle(&mut thread_rng());
+    let mut handles = Vec::with_capacity(solve::NUM_THREADS - 1);
+    for (i_thread, &mask) in solve::THREAD_MASKS.iter().skip(1).enumerate() {
+        let monitor_clone = monitor.clone();
+        handles.push(thread::spawn(move || {
+            animated_mini_hunter(
+                monitor_clone,
+                solve::ThreadGuide {
+                    index: i_thread + 1,
+                    paint: mask,
+                    start: corner_starts[i_thread + 1],
+                    speed: animation,
+                },
+            );
+        }));
+    }
+    animated_mini_hunter(
+        monitor,
+        solve::ThreadGuide {
+            index: 0,
+            paint: solve::THREAD_MASKS[0],
+            start: corner_starts[0],
+            speed: animation,
+        },
+    );
+    for handle in handles {
+        handle.join().unwrap();
+    }
+}
 // Dispatch Functions for each Thread--------------------------------------------------------------
 
 fn hunter(monitor: solve::SolverMonitor, guide: solve::ThreadGuide) {
@@ -434,6 +594,64 @@ fn animated_hunter(monitor: solve::SolverMonitor, guide: solve::ThreadGuide) {
     }
 }
 
+fn animated_mini_hunter(monitor: solve::SolverMonitor, guide: solve::ThreadGuide) {
+    let seen: solve::ThreadCache = guide.paint << solve::THREAD_TAG_OFFSET;
+    let mut dfs: Vec<maze::Point> = Vec::with_capacity(solve::INITIAL_PATH_LEN);
+    dfs.push(guide.start);
+    let mut rng = thread_rng();
+    let mut rng_arr: Vec<usize> = (0..solve::NUM_DIRECTIONS).collect();
+    'branching: while let Some(&cur) = dfs.last() {
+        if let Ok(mut lk) = monitor.lock() {
+            if lk.maze.exit() || lk.win.is_some() {
+                return;
+            }
+            if (lk.maze[cur.row as usize][cur.col as usize] & solve::FINISH_BIT) != 0 {
+                lk.maze[cur.row as usize][cur.col as usize] |= seen | guide.paint;
+                solve::flush_mini_path_coordinate(&lk.maze, cur);
+                lk.win.get_or_insert(guide.index);
+                return;
+            }
+            lk.maze[cur.row as usize][cur.col as usize] |= seen | guide.paint;
+            solve::flush_mini_path_coordinate(&lk.maze, cur);
+        } else {
+            print::maze_panic!("Solve thread panic!");
+        }
+
+        thread::sleep(time::Duration::from_micros(guide.speed));
+
+        // Bias threads towards their original dispatch direction with do-while loop.
+        rng_arr.shuffle(&mut rng);
+        for &i in &rng_arr {
+            let p: &maze::Point = &maze::CARDINAL_DIRECTIONS[i];
+            let next = maze::Point {
+                row: cur.row + p.row,
+                col: cur.col + p.col,
+            };
+
+            if match monitor.lock() {
+                Ok(lk) => {
+                    (lk.maze[next.row as usize][next.col as usize] & seen) == 0
+                        && (lk.maze[next.row as usize][next.col as usize] & maze::PATH_BIT) != 0
+                }
+                Err(p) => print::maze_panic!("Solve thread panic: {}", p),
+            } {
+                dfs.push(next);
+                continue 'branching;
+            }
+        }
+
+        match monitor.lock() {
+            Ok(mut lk) => {
+                lk.maze[cur.row as usize][cur.col as usize] &= !guide.paint;
+                solve::flush_mini_path_coordinate(&lk.maze, cur);
+            }
+            Err(p) => print::maze_panic!("Solve thread panic!: {}", p),
+        }
+        thread::sleep(time::Duration::from_micros(guide.speed));
+        dfs.pop();
+    }
+}
+
 fn gatherer(monitor: solve::SolverMonitor, guide: solve::ThreadGuide) {
     let seen: solve::ThreadCache = guide.paint << solve::THREAD_TAG_OFFSET;
     let mut dfs: Vec<maze::Point> = Vec::with_capacity(solve::INITIAL_PATH_LEN);
@@ -533,6 +751,65 @@ fn animated_gatherer(monitor: solve::SolverMonitor, guide: solve::ThreadGuide) {
             Ok(mut lk) => {
                 lk.maze[cur.row as usize][cur.col as usize] &= !guide.paint;
                 solve::flush_cursor_path_coordinate(&lk.maze, cur);
+            }
+            Err(p) => print::maze_panic!("Solve thread panic!: {}", p),
+        };
+        thread::sleep(time::Duration::from_micros(guide.speed));
+        dfs.pop();
+    }
+}
+
+fn animated_mini_gatherer(monitor: solve::SolverMonitor, guide: solve::ThreadGuide) {
+    let seen: solve::ThreadCache = guide.paint << solve::THREAD_TAG_OFFSET;
+    let mut dfs: Vec<maze::Point> = Vec::with_capacity(solve::INITIAL_PATH_LEN);
+    dfs.push(guide.start);
+    let mut rng = thread_rng();
+    let mut rng_arr: Vec<usize> = (0..solve::NUM_DIRECTIONS).collect();
+    'branching: while let Some(&cur) = dfs.last() {
+        if let Ok(mut lk) = monitor.lock() {
+            if lk.maze.exit() {
+                return;
+            }
+            if (lk.maze[cur.row as usize][cur.col as usize] & solve::FINISH_BIT) != 0
+                && (lk.maze[cur.row as usize][cur.col as usize] & solve::CACHE_MASK) == 0
+            {
+                lk.maze[cur.row as usize][cur.col as usize] |= seen | guide.paint;
+                solve::flush_mini_path_coordinate(&lk.maze, cur);
+                return;
+            }
+            lk.maze[cur.row as usize][cur.col as usize] |= seen | guide.paint;
+            solve::flush_mini_path_coordinate(&lk.maze, cur);
+        } else {
+            print::maze_panic!("Solve thread panic!");
+        }
+
+        thread::sleep(time::Duration::from_micros(guide.speed));
+
+        // Bias threads towards their original dispatch direction with do-while loop.
+        rng_arr.shuffle(&mut rng);
+        for &i in &rng_arr {
+            let p: &maze::Point = &maze::CARDINAL_DIRECTIONS[i];
+            let next = maze::Point {
+                row: cur.row + p.row,
+                col: cur.col + p.col,
+            };
+
+            if match monitor.lock() {
+                Ok(lk) => {
+                    (lk.maze[next.row as usize][next.col as usize] & seen) == 0
+                        && (lk.maze[next.row as usize][next.col as usize] & maze::PATH_BIT) != 0
+                }
+                Err(p) => print::maze_panic!("Solve thread panic: {}", p),
+            } {
+                dfs.push(next);
+                continue 'branching;
+            }
+        }
+
+        match monitor.lock() {
+            Ok(mut lk) => {
+                lk.maze[cur.row as usize][cur.col as usize] &= !guide.paint;
+                solve::flush_mini_path_coordinate(&lk.maze, cur);
             }
             Err(p) => print::maze_panic!("Solve thread panic!: {}", p),
         };

--- a/maze_progs/solvers/src/solve.rs
+++ b/maze_progs/solvers/src/solve.rs
@@ -134,6 +134,19 @@ pub fn find_nearest_square(maze: &maze::Maze, choice: maze::Point) -> maze::Poin
 }
 
 pub fn print_paths(maze: &maze::Maze) {
+    if maze.style_index() == (maze::MazeStyle::Mini as usize) {
+        for r in 0..maze.row_size() {
+            for c in 0..maze.col_size() {
+                print_mini_point(maze, maze::Point { row: r, col: c });
+            }
+            match queue!(io::stdout(), Print('\n'),) {
+                Ok(_) => {}
+                Err(_) => maze_panic!("Could not print newline."),
+            }
+        }
+        print::flush();
+        return;
+    }
     for r in 0..maze.row_size() {
         for c in 0..maze.col_size() {
             print_point(maze, maze::Point { row: r, col: c });
@@ -154,7 +167,7 @@ pub fn flush_cursor_path_coordinate(maze: &maze::Maze, point: maze::Point) {
         },
         maze.offset(),
     );
-    let square = &maze[point.row as usize][point.col as usize];
+    let square = maze[point.row as usize][point.col as usize];
     // We have some special printing for the finish square. Not here.
     if (square & FINISH_BIT) != 0 {
         let ansi = key::thread_color_code(((square & THREAD_MASK) >> THREAD_TAG_OFFSET) as usize);
@@ -222,196 +235,140 @@ pub fn flush_mini_path_coordinate(maze: &maze::Maze, point: maze::Point) {
         },
         maze.offset(),
     );
-    let square = &maze[point.row as usize][point.col as usize];
+    let square = maze[point.row as usize][point.col as usize];
     let this_color = key::thread_color_code(((square & THREAD_MASK) >> THREAD_TAG_OFFSET) as usize);
-    if (square & FINISH_BIT) != 0 {
-        if point.row % 2 != 0 {
-            if point.row - 1 == 0
-                || (point.row - 1 >= 0
-                    && (maze[(point.row - 1) as usize][point.col as usize] & maze::PATH_BIT) == 0)
-            {
-                execute!(
-                    io::stdout(),
-                    SetAttribute(Attribute::SlowBlink),
-                    SetForegroundColor(Color::AnsiValue(key::ANSI_CYN)),
-                    SetBackgroundColor(Color::AnsiValue(this_color)),
-                    Print('▀'),
-                    ResetColor
-                )
-                .expect("printer broke.");
-                return;
-            }
-            execute!(
-                io::stdout(),
-                SetAttribute(Attribute::SlowBlink),
-                SetForegroundColor(Color::AnsiValue(key::ANSI_CYN)),
-                SetBackgroundColor(Color::AnsiValue(this_color)),
-                Print('■'),
-                ResetColor
-            )
-            .expect("printer broke.");
-        // point.row % 2 == 0
-        } else {
-            if point.row + 1 <= maze.row_size() - 1
-                && (maze[(point.row + 1) as usize][point.col as usize] & maze::PATH_BIT) != 0
-            {
-                execute!(
-                    io::stdout(),
-                    SetAttribute(Attribute::SlowBlink),
-                    SetBackgroundColor(Color::AnsiValue(this_color)),
-                    SetForegroundColor(Color::AnsiValue(key::ANSI_CYN)),
-                    Print('▀'),
-                    ResetColor
-                )
-                .expect("printer broke.");
-                return;
-            }
-            execute!(
-                io::stdout(),
-                SetAttribute(Attribute::SlowBlink),
-                SetBackgroundColor(Color::AnsiValue(this_color)),
-                SetForegroundColor(Color::AnsiValue(key::ANSI_CYN)),
-                Print('■'),
-                ResetColor
-            )
-            .expect("printer broke.");
-            return;
-        }
-    }
-    if (square & START_BIT) != 0 {
-        if point.row % 2 != 0 {
-            if point.row - 1 == 0
-                || (point.row - 1 >= 0
-                    && (maze[(point.row - 1) as usize][point.col as usize] & maze::PATH_BIT) == 0)
-            {
-                execute!(
-                    io::stdout(),
-                    SetBackgroundColor(Color::AnsiValue(key::ANSI_CYN)),
-                    Print('▀'),
-                    ResetColor
-                )
-                .expect("printer broke.");
-                return;
-            }
-            let neighbor_color = key::thread_color_code(
-                ((maze[(point.row - 1) as usize][point.col as usize] & THREAD_MASK)
-                    >> THREAD_TAG_OFFSET) as usize,
-            );
-            execute!(
-                io::stdout(),
-                SetForegroundColor(Color::AnsiValue(key::ANSI_CYN)),
-                SetBackgroundColor(Color::AnsiValue(neighbor_color)),
-                Print('■'),
-                ResetColor
-            )
-            .expect("printer broke.");
-        // point.row % 2 == 0
-        } else {
-            if point.row + 1 <= maze.row_size() - 1
-                && (maze[(point.row + 1) as usize][point.col as usize] & maze::PATH_BIT) == 0
-            {
-                execute!(
-                    io::stdout(),
-                    SetBackgroundColor(Color::AnsiValue(key::ANSI_CYN)),
-                    Print('■'),
-                    ResetColor
-                )
-                .expect("printer broke.");
-                return;
-            }
-            let neighbor_color = key::thread_color_code(
-                ((maze[(point.row + 1) as usize][point.col as usize] & THREAD_MASK)
-                    >> THREAD_TAG_OFFSET) as usize,
-            );
-            execute!(
-                io::stdout(),
-                SetBackgroundColor(Color::AnsiValue(neighbor_color)),
-                SetForegroundColor(Color::AnsiValue(key::ANSI_CYN)),
-                Print('▀'),
-                ResetColor
-            )
-            .expect("printer broke.");
-            return;
-        }
-    }
-    if (square & maze::PATH_BIT) == 0 {
-        let mut thread_color = 0;
-        if point.row % 2 != 0 && point.row - 1 >= 0 {
-            thread_color = key::thread_color_code(
-                ((maze[(point.row - 1) as usize][point.col as usize] & THREAD_MASK)
-                    >> THREAD_TAG_OFFSET) as usize,
-            );
-        } else if point.row + 1 < maze.row_size() {
-            thread_color = key::thread_color_code(
-                ((maze[(point.row + 1) as usize][point.col as usize] & THREAD_MASK)
-                    >> THREAD_TAG_OFFSET) as usize,
-            );
-        }
-        match execute!(
+    if (square & (FINISH_BIT | START_BIT)) != 0 {
+        execute!(
             io::stdout(),
-            SetBackgroundColor(Color::AnsiValue(thread_color)),
-            Print(maze.wall_char((square & maze::WALL_MASK) as usize)),
-            ResetColor,
-        ) {
-            Ok(_) => return,
-            Err(_) => maze_panic!("Could not print wall."),
-        }
-    // This is a path square.
-    } else {
+            SetAttribute(Attribute::SlowBlink),
+            SetBackgroundColor(Color::AnsiValue(this_color)),
+            SetForegroundColor(Color::AnsiValue(key::ANSI_CYN)),
+            Print('▀'),
+            ResetColor
+        )
+        .expect("printer broke.");
+        return;
+    }
+    // This is a path square. We should never be asked to print a wall from a solver animation?
+    assert!((square & maze::PATH_BIT) != 0);
+    if point.row % 2 != 0 {
+        let fg_color =
+            match (maze[(point.row - 1) as usize][point.col as usize] & maze::PATH_BIT) != 0 {
+                true => Color::AnsiValue(key::thread_color_code(
+                    ((maze[(point.row - 1) as usize][point.col as usize] & THREAD_MASK)
+                        >> THREAD_TAG_OFFSET) as usize,
+                )),
+                false => Color::Reset,
+            };
+        execute!(
+            io::stdout(),
+            SetForegroundColor(fg_color),
+            SetBackgroundColor(Color::AnsiValue(this_color)),
+            Print('▀'),
+            ResetColor
+        )
+        .expect("printer broke.");
+        return;
+    }
+    // Even rows but this still must be a path.
+    assert!((square & maze::PATH_BIT) != 0);
+    let fg_color = match (maze[(point.row + 1) as usize][point.col as usize] & maze::PATH_BIT) != 0
+    {
+        true => Color::AnsiValue(key::thread_color_code(
+            ((maze[(point.row + 1) as usize][point.col as usize] & THREAD_MASK)
+                >> THREAD_TAG_OFFSET) as usize,
+        )),
+        false => Color::Reset,
+    };
+    execute!(
+        io::stdout(),
+        SetForegroundColor(fg_color),
+        SetBackgroundColor(Color::AnsiValue(this_color)),
+        Print('■'),
+        ResetColor
+    )
+    .expect("printer broke.");
+}
+
+pub fn print_mini_point(maze: &maze::Maze, point: maze::Point) {
+    print::set_cursor_position(
+        maze::Point {
+            row: point.row / 2,
+            col: point.col,
+        },
+        maze.offset(),
+    );
+    let square = maze[point.row as usize][point.col as usize];
+    let this_color = key::thread_color_code(((square & THREAD_MASK) >> THREAD_TAG_OFFSET) as usize);
+    if (square & (FINISH_BIT | START_BIT)) != 0 {
+        queue!(
+            io::stdout(),
+            SetAttribute(Attribute::SlowBlink),
+            SetBackgroundColor(Color::AnsiValue(this_color)),
+            SetForegroundColor(Color::AnsiValue(key::ANSI_CYN)),
+            Print('▀'),
+            ResetColor
+        )
+        .expect("printer broke.");
+        return;
+    }
+    // This is a path square. We should never be asked to print a wall from a solver animation?
+    if square & maze::PATH_BIT != 0 {
         if point.row % 2 != 0 {
-            if point.row - 1 == 0
-                || (point.row - 1 >= 0
-                    && (maze[(point.row - 1) as usize][point.col as usize] & maze::PATH_BIT) == 0)
-            {
-                execute!(
-                    io::stdout(),
-                    SetBackgroundColor(Color::AnsiValue(this_color)),
-                    Print('▀'),
-                    ResetColor
-                )
-                .expect("printer broke.");
-                return;
-            }
-            let neighbor_color = key::thread_color_code(
-                ((maze[(point.row - 1) as usize][point.col as usize] & THREAD_MASK)
-                    >> THREAD_TAG_OFFSET) as usize,
-            );
-            execute!(
-                io::stdout(),
-                SetForegroundColor(Color::AnsiValue(neighbor_color)),
-                SetBackgroundColor(Color::AnsiValue(this_color)),
-                Print('▀'),
-                ResetColor
-            )
-            .expect("printer broke.");
-        // point.row % 2 == 0
-        } else {
-            if point.row + 1 <= maze.row_size() - 1
-                && (maze[(point.row + 1) as usize][point.col as usize] & maze::PATH_BIT) != 0
-            {
-                let neighbor_color = key::thread_color_code(
-                    ((maze[(point.row + 1) as usize][point.col as usize] & THREAD_MASK)
+            if (maze[(point.row - 1) as usize][point.col as usize] & maze::PATH_BIT) != 0 {
+                let neighbor = key::thread_color_code(
+                    ((maze[(point.row - 1) as usize][point.col as usize] & THREAD_MASK)
                         >> THREAD_TAG_OFFSET) as usize,
                 );
-                execute!(
+                queue!(
                     io::stdout(),
+                    SetForegroundColor(Color::AnsiValue(neighbor)),
                     SetBackgroundColor(Color::AnsiValue(this_color)),
-                    SetForegroundColor(Color::AnsiValue(neighbor_color)),
-                    Print('■'),
+                    Print('▀'),
                     ResetColor
                 )
                 .expect("printer broke.");
                 return;
             }
-            execute!(
+            queue!(
                 io::stdout(),
                 SetBackgroundColor(Color::AnsiValue(this_color)),
-                Print('■'),
+                Print('▀'),
                 ResetColor
             )
             .expect("printer broke.");
+            return;
         }
+        // Even rows but this still must be a path.
+        if (maze[(point.row + 1) as usize][point.col as usize] & maze::PATH_BIT) != 0 {
+            let neighbor = key::thread_color_code(
+                ((maze[(point.row + 1) as usize][point.col as usize] & THREAD_MASK)
+                    >> THREAD_TAG_OFFSET) as usize,
+            );
+            queue!(
+                io::stdout(),
+                SetForegroundColor(Color::AnsiValue(neighbor)),
+                SetBackgroundColor(Color::AnsiValue(this_color)),
+                Print('▀'),
+                ResetColor
+            )
+            .expect("printer broke.");
+            return;
+        }
+        queue!(
+            io::stdout(),
+            SetBackgroundColor(Color::AnsiValue(this_color)),
+            Print('▀'),
+            ResetColor
+        )
+        .expect("printer broke.");
+        return;
     }
+    queue!(
+        io::stdout(),
+        Print(maze.wall_char((square & maze::WALL_MASK) as usize)),
+    )
+    .expect("printer broke.");
 }
 
 pub fn print_point(maze: &maze::Maze, point: maze::Point) {

--- a/maze_progs/solvers/src/solve.rs
+++ b/maze_progs/solvers/src/solve.rs
@@ -252,17 +252,23 @@ pub fn flush_mini_path_coordinate(maze: &maze::Maze, point: maze::Point) {
     // This is a path square. We should never be asked to print a wall from a solver animation?
     assert!((square & maze::PATH_BIT) != 0);
     if point.row % 2 != 0 {
-        let fg_color =
-            match (maze[(point.row - 1) as usize][point.col as usize] & maze::PATH_BIT) != 0 {
-                true => Color::AnsiValue(key::thread_color_code(
-                    ((maze[(point.row - 1) as usize][point.col as usize] & THREAD_MASK)
-                        >> THREAD_TAG_OFFSET) as usize,
-                )),
-                false => Color::Reset,
-            };
+        if (maze[(point.row - 1) as usize][point.col as usize] & maze::PATH_BIT) != 0 {
+            let neighbor = key::thread_color_code(
+                ((maze[(point.row - 1) as usize][point.col as usize] & THREAD_MASK)
+                    >> THREAD_TAG_OFFSET) as usize,
+            );
+            execute!(
+                io::stdout(),
+                SetForegroundColor(Color::AnsiValue(neighbor)),
+                SetBackgroundColor(Color::AnsiValue(this_color)),
+                Print('▀'),
+                ResetColor
+            )
+            .expect("printer broke.");
+            return;
+        }
         execute!(
             io::stdout(),
-            SetForegroundColor(fg_color),
             SetBackgroundColor(Color::AnsiValue(this_color)),
             Print('▀'),
             ResetColor
@@ -272,19 +278,25 @@ pub fn flush_mini_path_coordinate(maze: &maze::Maze, point: maze::Point) {
     }
     // Even rows but this still must be a path.
     assert!((square & maze::PATH_BIT) != 0);
-    let fg_color = match (maze[(point.row + 1) as usize][point.col as usize] & maze::PATH_BIT) != 0
-    {
-        true => Color::AnsiValue(key::thread_color_code(
+    if (maze[(point.row + 1) as usize][point.col as usize] & maze::PATH_BIT) != 0 {
+        let neighbor = key::thread_color_code(
             ((maze[(point.row + 1) as usize][point.col as usize] & THREAD_MASK)
                 >> THREAD_TAG_OFFSET) as usize,
-        )),
-        false => Color::Reset,
-    };
+        );
+        execute!(
+            io::stdout(),
+            SetForegroundColor(Color::AnsiValue(neighbor)),
+            SetBackgroundColor(Color::AnsiValue(this_color)),
+            Print('▀'),
+            ResetColor
+        )
+        .expect("printer broke.");
+        return;
+    }
     execute!(
         io::stdout(),
-        SetForegroundColor(fg_color),
         SetBackgroundColor(Color::AnsiValue(this_color)),
-        Print('■'),
+        Print('▀'),
         ResetColor
     )
     .expect("printer broke.");

--- a/maze_progs/solvers/src/solve.rs
+++ b/maze_progs/solvers/src/solve.rs
@@ -198,7 +198,7 @@ pub fn flush_cursor_path_coordinate(maze: &maze::Maze, point: maze::Point) {
     if (square & maze::PATH_BIT) == 0 {
         match execute!(
             io::stdout(),
-            Print(maze.wall_style()[(square & maze::WALL_MASK) as usize]),
+            Print(maze.wall_char((square & maze::WALL_MASK) as usize)),
         ) {
             Ok(_) => return,
             Err(_) => maze_panic!("Could not print wall."),
@@ -265,7 +265,7 @@ pub fn print_point(maze: &maze::Maze, point: maze::Point) {
     if (square & maze::PATH_BIT) == 0 {
         match queue!(
             io::stdout(),
-            Print(maze.wall_style()[(square & maze::WALL_MASK) as usize]),
+            Print(maze.wall_char((square & maze::WALL_MASK) as usize)),
         ) {
             Ok(_) => return,
             Err(_) => maze_panic!("Could not print wall."),

--- a/maze_progs/solvers/src/solve.rs
+++ b/maze_progs/solvers/src/solve.rs
@@ -227,251 +227,6 @@ pub fn flush_cursor_path_coordinate(maze: &maze::Maze, point: maze::Point) {
     maze_panic!("Uncategorized maze square! Check the bits.");
 }
 
-pub fn flush_mini_path_coordinate(maze: &maze::Maze, point: maze::Point) {
-    print::set_cursor_position(
-        maze::Point {
-            row: point.row / 2,
-            col: point.col,
-        },
-        maze.offset(),
-    );
-    let square = maze[point.row as usize][point.col as usize];
-    let this_color = key::thread_color_code(((square & THREAD_MASK) >> THREAD_TAG_OFFSET) as usize);
-    if (square & (FINISH_BIT | START_BIT)) != 0 {
-        execute!(
-            io::stdout(),
-            SetAttribute(Attribute::SlowBlink),
-            SetBackgroundColor(Color::AnsiValue(this_color)),
-            SetForegroundColor(Color::AnsiValue(key::ANSI_CYN)),
-            Print('▀'),
-            ResetColor
-        )
-        .expect("printer broke.");
-        return;
-    }
-    // This is a path square. We should never be asked to print a wall from a solver animation?
-    assert!((square & maze::PATH_BIT) != 0);
-    if point.row % 2 != 0 {
-        if (maze[(point.row - 1) as usize][point.col as usize] & maze::PATH_BIT) != 0 {
-            let neighbor_square = maze[(point.row - 1) as usize][point.col as usize];
-            let mut neighbor_color = key::thread_color_code(
-                ((neighbor_square & THREAD_MASK) >> THREAD_TAG_OFFSET) as usize,
-            );
-            if (neighbor_square & (START_BIT | FINISH_BIT)) != 0 {
-                neighbor_color = key::ANSI_CYN;
-                queue!(io::stdout(), SetAttribute(Attribute::SlowBlink),).expect("printer broke.");
-            }
-            execute!(
-                io::stdout(),
-                SetForegroundColor(Color::AnsiValue(neighbor_color)),
-                SetBackgroundColor(Color::AnsiValue(this_color)),
-                Print('▀'),
-                ResetColor
-            )
-            .expect("printer broke.");
-            return;
-        }
-        execute!(
-            io::stdout(),
-            SetBackgroundColor(Color::AnsiValue(this_color)),
-            Print('▀'),
-            ResetColor
-        )
-        .expect("printer broke.");
-        return;
-    }
-    // Even rows but this still must be a path.
-    assert!((square & maze::PATH_BIT) != 0);
-    if (maze[(point.row + 1) as usize][point.col as usize] & maze::PATH_BIT) != 0 {
-        let neighbor_square = maze[(point.row + 1) as usize][point.col as usize];
-        let mut neighbor_color =
-            key::thread_color_code(((neighbor_square & THREAD_MASK) >> THREAD_TAG_OFFSET) as usize);
-        if (neighbor_square & (START_BIT | FINISH_BIT)) != 0 {
-            neighbor_color = key::ANSI_CYN;
-            queue!(io::stdout(), SetAttribute(Attribute::SlowBlink),).expect("printer broke.");
-        }
-        execute!(
-            io::stdout(),
-            SetForegroundColor(Color::AnsiValue(neighbor_color)),
-            SetBackgroundColor(Color::AnsiValue(this_color)),
-            Print('▀'),
-            ResetColor
-        )
-        .expect("printer broke.");
-        return;
-    }
-    execute!(
-        io::stdout(),
-        SetBackgroundColor(Color::AnsiValue(this_color)),
-        Print('▀'),
-        ResetColor
-    )
-    .expect("printer broke.");
-}
-
-pub fn flush_dark_mini_path_coordinate(maze: &maze::Maze, point: maze::Point) {
-    print::set_cursor_position(
-        maze::Point {
-            row: point.row / 2,
-            col: point.col,
-        },
-        maze.offset(),
-    );
-    let square = maze[point.row as usize][point.col as usize];
-    let this_color = key::thread_color_code(((square & THREAD_MASK) >> THREAD_TAG_OFFSET) as usize);
-    if (square & (FINISH_BIT | START_BIT)) != 0 {
-        execute!(
-            io::stdout(),
-            SetAttribute(Attribute::SlowBlink),
-            SetBackgroundColor(Color::AnsiValue(this_color)),
-            SetForegroundColor(Color::AnsiValue(key::ANSI_CYN)),
-            Print('▀'),
-            ResetColor
-        )
-        .expect("printer broke.");
-        return;
-    }
-    // This is a path square. We should never be asked to print a wall from a solver animation?
-    assert!((square & maze::PATH_BIT) != 0);
-    if point.row % 2 != 0 {
-        if (maze[(point.row - 1) as usize][point.col as usize] & maze::PATH_BIT) != 0 {
-            let neighbor_square = maze[(point.row - 1) as usize][point.col as usize];
-            let mut neighbor_color = key::thread_color_code(
-                ((neighbor_square & THREAD_MASK) >> THREAD_TAG_OFFSET) as usize,
-            );
-            if (neighbor_square & (START_BIT | FINISH_BIT)) != 0 {
-                neighbor_color = key::ANSI_CYN;
-                queue!(io::stdout(), SetAttribute(Attribute::SlowBlink),).expect("printer broke.");
-            }
-            execute!(
-                io::stdout(),
-                SetForegroundColor(Color::AnsiValue(neighbor_color)),
-                SetBackgroundColor(Color::AnsiValue(this_color)),
-                Print('▀'),
-                ResetColor
-            )
-            .expect("printer broke.");
-            return;
-        }
-        execute!(
-            io::stdout(),
-            SetForegroundColor(Color::AnsiValue(this_color)),
-            Print('▄'),
-            ResetColor
-        )
-        .expect("printer broke.");
-        return;
-    }
-    // Even rows but this still must be a path.
-    assert!((square & maze::PATH_BIT) != 0);
-    if (maze[(point.row + 1) as usize][point.col as usize] & maze::PATH_BIT) != 0 {
-        let neighbor_square = maze[(point.row + 1) as usize][point.col as usize];
-        let mut neighbor_color =
-            key::thread_color_code(((neighbor_square & THREAD_MASK) >> THREAD_TAG_OFFSET) as usize);
-        if (neighbor_square & (START_BIT | FINISH_BIT)) != 0 {
-            neighbor_color = key::ANSI_CYN;
-            queue!(io::stdout(), SetAttribute(Attribute::SlowBlink),).expect("printer broke.");
-        }
-        execute!(
-            io::stdout(),
-            SetForegroundColor(Color::AnsiValue(neighbor_color)),
-            SetBackgroundColor(Color::AnsiValue(this_color)),
-            Print('▀'),
-            ResetColor
-        )
-        .expect("printer broke.");
-        return;
-    }
-    execute!(
-        io::stdout(),
-        SetForegroundColor(Color::AnsiValue(this_color)),
-        Print('▀'),
-        ResetColor
-    )
-    .expect("printer broke.");
-}
-
-pub fn print_mini_point(maze: &maze::Maze, point: maze::Point) {
-    print::set_cursor_position(
-        maze::Point {
-            row: point.row / 2,
-            col: point.col,
-        },
-        maze.offset(),
-    );
-    let square = maze[point.row as usize][point.col as usize];
-    let this_color = key::thread_color_code(((square & THREAD_MASK) >> THREAD_TAG_OFFSET) as usize);
-    if (square & (FINISH_BIT | START_BIT)) != 0 {
-        queue!(
-            io::stdout(),
-            SetAttribute(Attribute::SlowBlink),
-            SetBackgroundColor(Color::AnsiValue(this_color)),
-            SetForegroundColor(Color::AnsiValue(key::ANSI_CYN)),
-            Print('▀'),
-            ResetColor
-        )
-        .expect("printer broke.");
-        return;
-    }
-    // This is a path square. We should never be asked to print a wall from a solver animation?
-    if square & maze::PATH_BIT != 0 {
-        if point.row % 2 != 0 {
-            if (maze[(point.row - 1) as usize][point.col as usize] & maze::PATH_BIT) != 0 {
-                let neighbor = key::thread_color_code(
-                    ((maze[(point.row - 1) as usize][point.col as usize] & THREAD_MASK)
-                        >> THREAD_TAG_OFFSET) as usize,
-                );
-                queue!(
-                    io::stdout(),
-                    SetForegroundColor(Color::AnsiValue(neighbor)),
-                    SetBackgroundColor(Color::AnsiValue(this_color)),
-                    Print('▀'),
-                    ResetColor
-                )
-                .expect("printer broke.");
-                return;
-            }
-            queue!(
-                io::stdout(),
-                SetBackgroundColor(Color::AnsiValue(this_color)),
-                Print('▀'),
-                ResetColor
-            )
-            .expect("printer broke.");
-            return;
-        }
-        // Even rows but this still must be a path.
-        if (maze[(point.row + 1) as usize][point.col as usize] & maze::PATH_BIT) != 0 {
-            let neighbor = key::thread_color_code(
-                ((maze[(point.row + 1) as usize][point.col as usize] & THREAD_MASK)
-                    >> THREAD_TAG_OFFSET) as usize,
-            );
-            queue!(
-                io::stdout(),
-                SetForegroundColor(Color::AnsiValue(neighbor)),
-                SetBackgroundColor(Color::AnsiValue(this_color)),
-                Print('▀'),
-                ResetColor
-            )
-            .expect("printer broke.");
-            return;
-        }
-        queue!(
-            io::stdout(),
-            SetBackgroundColor(Color::AnsiValue(this_color)),
-            Print('▀'),
-            ResetColor
-        )
-        .expect("printer broke.");
-        return;
-    }
-    queue!(
-        io::stdout(),
-        Print(maze.wall_char((square & maze::WALL_MASK) as usize)),
-    )
-    .expect("printer broke.");
-}
-
 pub fn print_point(maze: &maze::Maze, point: maze::Point) {
     print::set_cursor_position(
         maze::Point {
@@ -537,6 +292,307 @@ pub fn print_point(maze: &maze::Maze, point: maze::Point) {
         }
     }
     maze_panic!("Uncategorized maze square! Check the bits.");
+}
+
+// These printers for the Mini wall style are brutal. If you ever think of something better, fix.
+
+pub fn flush_mini_path_coordinate(maze: &maze::Maze, point: maze::Point) {
+    print::set_cursor_position(
+        maze::Point {
+            row: point.row / 2,
+            col: point.col,
+        },
+        maze.offset(),
+    );
+    let square = maze[point.row as usize][point.col as usize];
+    let this_color = key::thread_color_code(((square & THREAD_MASK) >> THREAD_TAG_OFFSET) as usize);
+    if (square & (FINISH_BIT | START_BIT)) != 0 {
+        execute!(
+            io::stdout(),
+            SetAttribute(Attribute::SlowBlink),
+            SetBackgroundColor(Color::AnsiValue(this_color)),
+            SetForegroundColor(Color::AnsiValue(key::ANSI_CYN)),
+            Print('▀'),
+            ResetColor
+        )
+        .expect("printer broke.");
+        return;
+    }
+    // This is a path square. We should never be asked to print a wall from a solver animation?
+    if point.row % 2 != 0 {
+        if (maze[(point.row - 1) as usize][point.col as usize] & maze::PATH_BIT) != 0 {
+            let neighbor_square = maze[(point.row - 1) as usize][point.col as usize];
+            if (neighbor_square & (START_BIT | FINISH_BIT)) != 0 {
+                execute!(
+                    io::stdout(),
+                    SetAttribute(Attribute::SlowBlink),
+                    SetForegroundColor(Color::AnsiValue(key::ANSI_CYN)),
+                    SetBackgroundColor(Color::AnsiValue(this_color)),
+                    Print('▀'),
+                    ResetColor
+                )
+                .expect("printer broke.");
+                return;
+            }
+            execute!(
+                io::stdout(),
+                SetForegroundColor(Color::AnsiValue(key::thread_color_code(
+                    ((neighbor_square & THREAD_MASK) >> THREAD_TAG_OFFSET) as usize,
+                ))),
+                SetBackgroundColor(Color::AnsiValue(this_color)),
+                Print('▀'),
+                ResetColor
+            )
+            .expect("printer broke.");
+            return;
+        }
+        // A wall is above us.
+        execute!(
+            io::stdout(),
+            SetBackgroundColor(Color::AnsiValue(this_color)),
+            Print('▀'),
+            ResetColor
+        )
+        .expect("printer broke.");
+        return;
+    }
+    // Even rows but this still must be a path.
+    if (maze[(point.row + 1) as usize][point.col as usize] & maze::PATH_BIT) != 0 {
+        let neighbor_square = maze[(point.row + 1) as usize][point.col as usize];
+        if (neighbor_square & (START_BIT | FINISH_BIT)) != 0 {
+            execute!(
+                io::stdout(),
+                SetAttribute(Attribute::SlowBlink),
+                SetForegroundColor(Color::AnsiValue(key::ANSI_CYN)),
+                SetBackgroundColor(Color::AnsiValue(this_color)),
+                Print('▀'),
+                ResetColor
+            )
+            .expect("printer broke.");
+            return;
+        }
+        execute!(
+            io::stdout(),
+            SetForegroundColor(Color::AnsiValue(key::thread_color_code(
+                ((neighbor_square & THREAD_MASK) >> THREAD_TAG_OFFSET) as usize
+            ))),
+            SetBackgroundColor(Color::AnsiValue(this_color)),
+            Print('▀'),
+            ResetColor
+        )
+        .expect("printer broke.");
+        return;
+    }
+    // A wall is above us
+    execute!(
+        io::stdout(),
+        SetBackgroundColor(Color::AnsiValue(this_color)),
+        Print('▀'),
+        ResetColor
+    )
+    .expect("printer broke.");
+}
+
+pub fn print_mini_point(maze: &maze::Maze, point: maze::Point) {
+    print::set_cursor_position(
+        maze::Point {
+            row: point.row / 2,
+            col: point.col,
+        },
+        maze.offset(),
+    );
+    let square = maze[point.row as usize][point.col as usize];
+    let this_color = key::thread_color_code(((square & THREAD_MASK) >> THREAD_TAG_OFFSET) as usize);
+    if (square & (FINISH_BIT | START_BIT)) != 0 {
+        queue!(
+            io::stdout(),
+            SetAttribute(Attribute::SlowBlink),
+            SetBackgroundColor(Color::AnsiValue(this_color)),
+            SetForegroundColor(Color::AnsiValue(key::ANSI_CYN)),
+            Print('▀'),
+            ResetColor
+        )
+        .expect("printer broke.");
+        return;
+    }
+    if square & maze::PATH_BIT == 0 {
+        queue!(
+            io::stdout(),
+            Print(maze.wall_char((square & maze::WALL_MASK) as usize)),
+        )
+        .expect("printer broke.");
+        return;
+    }
+    if point.row % 2 != 0 {
+        if (maze[(point.row - 1) as usize][point.col as usize] & maze::PATH_BIT) != 0 {
+            let neighbor_square = maze[(point.row - 1) as usize][point.col as usize];
+            if (neighbor_square & (START_BIT | FINISH_BIT)) != 0 {
+                queue!(
+                    io::stdout(),
+                    SetAttribute(Attribute::SlowBlink),
+                    SetForegroundColor(Color::AnsiValue(key::ANSI_CYN)),
+                    SetBackgroundColor(Color::AnsiValue(this_color)),
+                    Print('▀'),
+                    ResetColor
+                )
+                .expect("printer broke.");
+                return;
+            }
+            queue!(
+                io::stdout(),
+                SetForegroundColor(Color::AnsiValue(key::thread_color_code(
+                    ((neighbor_square & THREAD_MASK) >> THREAD_TAG_OFFSET) as usize,
+                ))),
+                SetBackgroundColor(Color::AnsiValue(this_color)),
+                Print('▀'),
+                ResetColor
+            )
+            .expect("printer broke.");
+            return;
+        }
+        // A wall is above us.
+        queue!(
+            io::stdout(),
+            SetBackgroundColor(Color::AnsiValue(this_color)),
+            Print('▀'),
+            ResetColor
+        )
+        .expect("printer broke.");
+        return;
+    }
+    // Even rows but this still must be a path.
+    if (maze[(point.row + 1) as usize][point.col as usize] & maze::PATH_BIT) != 0 {
+        let neighbor_square = maze[(point.row + 1) as usize][point.col as usize];
+        if (neighbor_square & (START_BIT | FINISH_BIT)) != 0 {
+            queue!(
+                io::stdout(),
+                SetAttribute(Attribute::SlowBlink),
+                SetForegroundColor(Color::AnsiValue(key::ANSI_CYN)),
+                SetBackgroundColor(Color::AnsiValue(this_color)),
+                Print('▀'),
+                ResetColor
+            )
+            .expect("printer broke.");
+            return;
+        }
+        queue!(
+            io::stdout(),
+            SetForegroundColor(Color::AnsiValue(key::thread_color_code(
+                ((neighbor_square & THREAD_MASK) >> THREAD_TAG_OFFSET) as usize
+            ))),
+            SetBackgroundColor(Color::AnsiValue(this_color)),
+            Print('▀'),
+            ResetColor
+        )
+        .expect("printer broke.");
+        return;
+    }
+    // A wall is above us.
+    queue!(
+        io::stdout(),
+        SetBackgroundColor(Color::AnsiValue(this_color)),
+        Print('▀'),
+        ResetColor
+    )
+    .expect("printer broke.");
+}
+
+// Because we are using half blocks we need a different function to invert colors for dark mode.
+pub fn flush_dark_mini_path_coordinate(maze: &maze::Maze, point: maze::Point) {
+    print::set_cursor_position(
+        maze::Point {
+            row: point.row / 2,
+            col: point.col,
+        },
+        maze.offset(),
+    );
+    let square = maze[point.row as usize][point.col as usize];
+    let this_color = key::thread_color_code(((square & THREAD_MASK) >> THREAD_TAG_OFFSET) as usize);
+    if (square & (FINISH_BIT | START_BIT)) != 0 {
+        execute!(
+            io::stdout(),
+            SetAttribute(Attribute::SlowBlink),
+            SetBackgroundColor(Color::AnsiValue(this_color)),
+            SetForegroundColor(Color::AnsiValue(key::ANSI_CYN)),
+            Print('▀'),
+            ResetColor
+        )
+        .expect("printer broke.");
+        return;
+    }
+    // This is a path square. We should never be asked to print a wall from a solver animation?
+    if point.row % 2 != 0 {
+        if (maze[(point.row - 1) as usize][point.col as usize] & maze::PATH_BIT) != 0 {
+            let neighbor_square = maze[(point.row - 1) as usize][point.col as usize];
+            if (neighbor_square & (START_BIT | FINISH_BIT)) != 0 {
+                execute!(
+                    io::stdout(),
+                    SetAttribute(Attribute::SlowBlink),
+                    SetForegroundColor(Color::AnsiValue(key::ANSI_CYN)),
+                    SetBackgroundColor(Color::AnsiValue(this_color)),
+                    Print('▀'),
+                    ResetColor
+                )
+                .expect("printer broke.");
+                return;
+            }
+            execute!(
+                io::stdout(),
+                SetForegroundColor(Color::AnsiValue(key::thread_color_code(
+                    ((neighbor_square & THREAD_MASK) >> THREAD_TAG_OFFSET) as usize,
+                ))),
+                SetBackgroundColor(Color::AnsiValue(this_color)),
+                Print('▀'),
+                ResetColor
+            )
+            .expect("printer broke.");
+            return;
+        }
+        // A wall above but we are in dark mode so make it black. Path is now square.
+        execute!(
+            io::stdout(),
+            SetForegroundColor(Color::AnsiValue(this_color)),
+            Print('▄'),
+            ResetColor
+        )
+        .expect("printer broke.");
+        return;
+    }
+    // Even rows but this still must be a path.
+    if (maze[(point.row + 1) as usize][point.col as usize] & maze::PATH_BIT) != 0 {
+        let neighbor_square = maze[(point.row + 1) as usize][point.col as usize];
+        if (neighbor_square & (START_BIT | FINISH_BIT)) != 0 {
+            execute!(
+                io::stdout(),
+                SetAttribute(Attribute::SlowBlink),
+                SetForegroundColor(Color::AnsiValue(key::ANSI_CYN)),
+                SetBackgroundColor(Color::AnsiValue(this_color)),
+                Print('▀'),
+                ResetColor
+            )
+            .expect("printer broke.");
+            return;
+        }
+        execute!(
+            io::stdout(),
+            SetForegroundColor(Color::AnsiValue(key::thread_color_code(
+                ((neighbor_square & THREAD_MASK) >> THREAD_TAG_OFFSET) as usize
+            ))),
+            SetBackgroundColor(Color::AnsiValue(this_color)),
+            Print('▀'),
+            ResetColor
+        )
+        .expect("printer broke.");
+        return;
+    }
+    // A wall above but we are in dark mode so make it black. Path is now square.
+    execute!(
+        io::stdout(),
+        SetForegroundColor(Color::AnsiValue(this_color)),
+        Print('▀'),
+        ResetColor
+    )
+    .expect("printer broke.");
 }
 
 pub fn deluminate_maze(maze: &maze::Maze) {

--- a/maze_progs/tables/src/lib.rs
+++ b/maze_progs/tables/src/lib.rs
@@ -92,7 +92,8 @@ pub const FLAGS: [(&'static str, &'static str); 6] = [
     ("-ba", "-ba"),
 ];
 
-pub const WALL_STYLES: [(&'static str, maze::MazeStyle); 7] = [
+pub const WALL_STYLES: [(&'static str, maze::MazeStyle); 8] = [
+    ("mini", maze::MazeStyle::Mini),
     ("sharp", maze::MazeStyle::Sharp),
     ("round", maze::MazeStyle::Round),
     ("doubles", maze::MazeStyle::Doubles),
@@ -101,6 +102,7 @@ pub const WALL_STYLES: [(&'static str, maze::MazeStyle); 7] = [
     ("half", maze::MazeStyle::Half),
     ("spikes", maze::MazeStyle::Spikes),
 ];
+
 pub const BUILDERS: [(&'static str, BuildFunction); 9] = [
     ("arena", (arena::generate_maze, arena::animate_maze)),
     (
@@ -130,10 +132,12 @@ pub const BUILDERS: [(&'static str, BuildFunction); 9] = [
     ),
     ("grid", (grid::generate_maze, grid::animate_maze)),
 ];
+
 pub const MODIFICATIONS: [(&'static str, BuildFunction); 2] = [
     ("cross", (modify::add_cross, modify::add_cross_animated)),
     ("x", (modify::add_x, modify::add_x_animated)),
 ];
+
 pub const SOLVERS: [(&'static str, SolveFunction); 26] = [
     ("dfs-hunt", (dfs::hunt, dfs::animate_hunt)),
     ("dfs-gather", (dfs::gather, dfs::animate_gather)),
@@ -177,6 +181,7 @@ pub const SOLVERS: [(&'static str, SolveFunction); 26] = [
     ),
     ("runs", (runs::paint_run_lengths, runs::animate_run_lengths)),
 ];
+
 pub const SPEEDS: [(&'static str, speed::Speed); 7] = [
     ("1", speed::Speed::Speed1),
     ("2", speed::Speed::Speed2),

--- a/maze_progs/tables/src/lib.rs
+++ b/maze_progs/tables/src/lib.rs
@@ -21,14 +21,9 @@ pub use solvers::floodfs;
 pub use solvers::rdfs;
 pub use solvers::solve;
 
-pub type BuildFunction = (
-    fn(&mut maze::Maze),
-    fn(&mut maze::Maze, speed::Speed),
-    fn(&mut maze::Maze, speed::Speed),
-);
+pub type BuildFunction = (fn(&mut maze::Maze), fn(&mut maze::Maze, speed::Speed));
 pub type SolveFunction = (
     fn(solve::SolverMonitor),
-    fn(solve::SolverMonitor, speed::Speed),
     fn(solve::SolverMonitor, speed::Speed),
 );
 
@@ -69,12 +64,11 @@ impl MazeRunner {
             build: (
                 recursive_backtracker::generate_maze,
                 recursive_backtracker::animate_maze,
-                recursive_backtracker::animate_mini_maze,
             ),
             modify: None,
             solve_view: ViewingMode::StaticImage,
             solve_speed: speed::Speed::Speed4,
-            solve: (dfs::hunt, dfs::animate_hunt, dfs::animate_mini_hunt),
+            solve: (dfs::hunt, dfs::animate_hunt),
         }
     }
 }
@@ -110,20 +104,12 @@ pub const WALL_STYLES: [(&'static str, maze::MazeStyle); 8] = [
 ];
 
 pub const BUILDERS: [(&'static str, BuildFunction); 9] = [
-    (
-        "arena",
-        (
-            arena::generate_maze,
-            arena::animate_maze,
-            arena::animate_mini_maze,
-        ),
-    ),
+    ("arena", (arena::generate_maze, arena::animate_maze)),
     (
         "rdfs",
         (
             recursive_backtracker::generate_maze,
             recursive_backtracker::animate_maze,
-            recursive_backtracker::animate_mini_maze,
         ),
     ),
     (
@@ -131,251 +117,69 @@ pub const BUILDERS: [(&'static str, BuildFunction); 9] = [
         (
             recursive_subdivision::generate_maze,
             recursive_subdivision::animate_maze,
-            recursive_subdivision::animate_mini_maze,
         ),
     ),
-    (
-        "prim",
-        (
-            prim::generate_maze,
-            prim::animate_maze,
-            prim::animate_mini_maze,
-        ),
-    ),
-    (
-        "kruskal",
-        (
-            kruskal::generate_maze,
-            kruskal::animate_maze,
-            kruskal::animate_mini_maze,
-        ),
-    ),
-    (
-        "eller",
-        (
-            eller::generate_maze,
-            eller::animate_maze,
-            eller::animate_mini_maze,
-        ),
-    ),
+    ("prim", (prim::generate_maze, prim::animate_maze)),
+    ("kruskal", (kruskal::generate_maze, kruskal::animate_maze)),
+    ("eller", (eller::generate_maze, eller::animate_maze)),
     (
         "wilson",
-        (
-            wilson_carver::generate_maze,
-            wilson_carver::animate_maze,
-            wilson_carver::animate_mini_maze,
-        ),
+        (wilson_carver::generate_maze, wilson_carver::animate_maze),
     ),
     (
         "wilson-walls",
-        (
-            wilson_adder::generate_maze,
-            wilson_adder::animate_maze,
-            wilson_adder::animate_mini_maze,
-        ),
+        (wilson_adder::generate_maze, wilson_adder::animate_maze),
     ),
-    (
-        "grid",
-        (
-            grid::generate_maze,
-            grid::animate_maze,
-            grid::animate_mini_maze,
-        ),
-    ),
+    ("grid", (grid::generate_maze, grid::animate_maze)),
 ];
 
 pub const MODIFICATIONS: [(&'static str, BuildFunction); 2] = [
-    (
-        "cross",
-        (
-            modify::add_cross,
-            modify::add_cross_animated,
-            modify::add_mini_cross_animated,
-        ),
-    ),
-    (
-        "x",
-        (
-            modify::add_x,
-            modify::add_x_animated,
-            modify::add_mini_x_animated,
-        ),
-    ),
+    ("cross", (modify::add_cross, modify::add_cross_animated)),
+    ("x", (modify::add_x, modify::add_x_animated)),
 ];
 
 pub const SOLVERS: [(&'static str, SolveFunction); 26] = [
-    (
-        "dfs-hunt",
-        (dfs::hunt, dfs::animate_hunt, dfs::animate_mini_hunt),
-    ),
-    (
-        "dfs-gather",
-        (dfs::gather, dfs::animate_gather, dfs::animate_mini_gather),
-    ),
-    (
-        "dfs-corner",
-        (dfs::corner, dfs::animate_corner, dfs::animate_mini_corner),
-    ),
-    (
-        "darkdfs-hunt",
-        (dfs::hunt, darkdfs::animate_hunt, darkdfs::animate_mini_hunt),
-    ),
-    (
-        "darkdfs-gather",
-        (
-            dfs::gather,
-            darkdfs::animate_gather,
-            darkdfs::animate_mini_gather,
-        ),
-    ),
-    (
-        "darkdfs-corner",
-        (
-            dfs::corner,
-            darkdfs::animate_corner,
-            darkdfs::animate_mini_corner,
-        ),
-    ),
-    (
-        "rdfs-hunt",
-        (rdfs::hunt, rdfs::animate_hunt, rdfs::animate_mini_hunt),
-    ),
-    (
-        "rdfs-gather",
-        (
-            rdfs::gather,
-            rdfs::animate_gather,
-            rdfs::animate_mini_gather,
-        ),
-    ),
-    (
-        "rdfs-corner",
-        (
-            rdfs::corner,
-            rdfs::animate_corner,
-            rdfs::animate_mini_corner,
-        ),
-    ),
-    (
-        "darkrdfs-hunt",
-        (
-            rdfs::hunt,
-            darkrdfs::animate_hunt,
-            darkrdfs::animate_mini_hunt,
-        ),
-    ),
-    (
-        "darkrdfs-gather",
-        (
-            rdfs::gather,
-            darkrdfs::animate_gather,
-            darkrdfs::animate_mini_gather,
-        ),
-    ),
-    (
-        "darkrdfs-corner",
-        (
-            rdfs::corner,
-            darkrdfs::animate_corner,
-            darkrdfs::animate_mini_corner,
-        ),
-    ),
-    (
-        "bfs-hunt",
-        (bfs::hunt, bfs::animate_hunt, bfs::animate_mini_hunt),
-    ),
-    (
-        "bfs-gather",
-        (bfs::gather, bfs::animate_gather, bfs::animate_mini_gather),
-    ),
-    (
-        "bfs-corner",
-        (bfs::corner, bfs::animate_corner, bfs::animate_mini_corner),
-    ),
-    (
-        "darkbfs-hunt",
-        (bfs::hunt, darkbfs::animate_hunt, darkbfs::animate_mini_hunt),
-    ),
-    (
-        "darkbfs-gather",
-        (
-            bfs::gather,
-            darkbfs::animate_gather,
-            darkbfs::animate_mini_gather,
-        ),
-    ),
-    (
-        "darkbfs-corner",
-        (
-            bfs::corner,
-            darkbfs::animate_corner,
-            darkbfs::animate_mini_corner,
-        ),
-    ),
-    (
-        "floodfs-hunt",
-        (
-            floodfs::hunt,
-            floodfs::animate_hunt,
-            floodfs::animate_mini_hunt,
-        ),
-    ),
-    (
-        "floodfs-gather",
-        (
-            floodfs::gather,
-            floodfs::animate_gather,
-            floodfs::animate_mini_gather,
-        ),
-    ),
-    (
-        "floodfs-corner",
-        (
-            floodfs::corner,
-            floodfs::animate_corner,
-            floodfs::animate_mini_corner,
-        ),
-    ),
+    ("dfs-hunt", (dfs::hunt, dfs::animate_hunt)),
+    ("dfs-gather", (dfs::gather, dfs::animate_gather)),
+    ("dfs-corner", (dfs::corner, dfs::animate_corner)),
+    ("darkdfs-hunt", (dfs::hunt, darkdfs::animate_hunt)),
+    ("darkdfs-gather", (dfs::gather, darkdfs::animate_gather)),
+    ("darkdfs-corner", (dfs::corner, darkdfs::animate_corner)),
+    ("rdfs-hunt", (rdfs::hunt, rdfs::animate_hunt)),
+    ("rdfs-gather", (rdfs::gather, rdfs::animate_gather)),
+    ("rdfs-corner", (rdfs::corner, rdfs::animate_corner)),
+    ("darkrdfs-hunt", (rdfs::hunt, darkrdfs::animate_hunt)),
+    ("darkrdfs-gather", (rdfs::gather, darkrdfs::animate_gather)),
+    ("darkrdfs-corner", (rdfs::corner, darkrdfs::animate_corner)),
+    ("bfs-hunt", (bfs::hunt, bfs::animate_hunt)),
+    ("bfs-gather", (bfs::gather, bfs::animate_gather)),
+    ("bfs-corner", (bfs::corner, bfs::animate_corner)),
+    ("darkbfs-hunt", (bfs::hunt, darkbfs::animate_hunt)),
+    ("darkbfs-gather", (bfs::gather, darkbfs::animate_gather)),
+    ("darkbfs-corner", (bfs::corner, darkbfs::animate_corner)),
+    ("floodfs-hunt", (floodfs::hunt, floodfs::animate_hunt)),
+    ("floodfs-gather", (floodfs::gather, floodfs::animate_gather)),
+    ("floodfs-corner", (floodfs::corner, floodfs::animate_corner)),
     (
         "darkfloodfs-hunt",
-        (
-            floodfs::hunt,
-            darkfloodfs::animate_hunt,
-            darkfloodfs::animate_mini_hunt,
-        ),
+        (floodfs::hunt, darkfloodfs::animate_hunt),
     ),
     (
         "darkfloodfs-gather",
-        (
-            floodfs::gather,
-            darkfloodfs::animate_gather,
-            darkfloodfs::animate_mini_gather,
-        ),
+        (floodfs::gather, darkfloodfs::animate_gather),
     ),
     (
         "darkfloodfs-corner",
-        (
-            floodfs::corner,
-            darkfloodfs::animate_corner,
-            darkfloodfs::animate_mini_corner,
-        ),
+        (floodfs::corner, darkfloodfs::animate_corner),
     ),
     (
         "distance",
         (
             distance::paint_distance_from_center,
             distance::animate_distance_from_center,
-            distance::animate_mini_distance_from_center,
         ),
     ),
-    (
-        "runs",
-        (
-            runs::paint_run_lengths,
-            runs::animate_run_lengths,
-            runs::animate_mini_run_lengths,
-        ),
-    ),
+    ("runs", (runs::paint_run_lengths, runs::animate_run_lengths)),
 ];
 
 pub const SPEEDS: [(&'static str, speed::Speed); 7] = [

--- a/maze_progs/tables/src/lib.rs
+++ b/maze_progs/tables/src/lib.rs
@@ -210,22 +210,22 @@ pub const SOLVERS: [(&'static str, SolveFunction); 26] = [
     ),
     (
         "dfs-gather",
-        (dfs::gather, dfs::animate_gather, dfs::animate_gather),
+        (dfs::gather, dfs::animate_gather, dfs::animate_mini_gather),
     ),
     (
         "dfs-corner",
-        (dfs::corner, dfs::animate_corner, dfs::animate_corner),
+        (dfs::corner, dfs::animate_corner, dfs::animate_mini_corner),
     ),
     (
         "darkdfs-hunt",
-        (dfs::hunt, darkdfs::animate_hunt, darkdfs::animate_hunt),
+        (dfs::hunt, darkdfs::animate_hunt, darkdfs::animate_mini_hunt),
     ),
     (
         "darkdfs-gather",
         (
             dfs::gather,
             darkdfs::animate_gather,
-            darkdfs::animate_gather,
+            darkdfs::animate_mini_gather,
         ),
     ),
     (
@@ -233,31 +233,43 @@ pub const SOLVERS: [(&'static str, SolveFunction); 26] = [
         (
             dfs::corner,
             darkdfs::animate_corner,
-            darkdfs::animate_corner,
+            darkdfs::animate_mini_corner,
         ),
     ),
     (
         "rdfs-hunt",
-        (rdfs::hunt, rdfs::animate_hunt, rdfs::animate_hunt),
+        (rdfs::hunt, rdfs::animate_hunt, rdfs::animate_mini_hunt),
     ),
     (
         "rdfs-gather",
-        (rdfs::gather, rdfs::animate_gather, rdfs::animate_gather),
+        (
+            rdfs::gather,
+            rdfs::animate_gather,
+            rdfs::animate_mini_gather,
+        ),
     ),
     (
         "rdfs-corner",
-        (rdfs::corner, rdfs::animate_corner, rdfs::animate_corner),
+        (
+            rdfs::corner,
+            rdfs::animate_corner,
+            rdfs::animate_mini_corner,
+        ),
     ),
     (
         "darkrdfs-hunt",
-        (rdfs::hunt, darkrdfs::animate_hunt, darkrdfs::animate_hunt),
+        (
+            rdfs::hunt,
+            darkrdfs::animate_hunt,
+            darkrdfs::animate_mini_hunt,
+        ),
     ),
     (
         "darkrdfs-gather",
         (
             rdfs::gather,
             darkrdfs::animate_gather,
-            darkrdfs::animate_gather,
+            darkrdfs::animate_mini_gather,
         ),
     ),
     (
@@ -265,31 +277,31 @@ pub const SOLVERS: [(&'static str, SolveFunction); 26] = [
         (
             rdfs::corner,
             darkrdfs::animate_corner,
-            darkrdfs::animate_corner,
+            darkrdfs::animate_mini_corner,
         ),
     ),
     (
         "bfs-hunt",
-        (bfs::hunt, bfs::animate_hunt, bfs::animate_hunt),
+        (bfs::hunt, bfs::animate_hunt, bfs::animate_mini_hunt),
     ),
     (
         "bfs-gather",
-        (bfs::gather, bfs::animate_gather, bfs::animate_gather),
+        (bfs::gather, bfs::animate_gather, bfs::animate_mini_gather),
     ),
     (
         "bfs-corner",
-        (bfs::corner, bfs::animate_corner, bfs::animate_corner),
+        (bfs::corner, bfs::animate_corner, bfs::animate_mini_corner),
     ),
     (
         "darkbfs-hunt",
-        (bfs::hunt, darkbfs::animate_hunt, darkbfs::animate_hunt),
+        (bfs::hunt, darkbfs::animate_hunt, darkbfs::animate_mini_hunt),
     ),
     (
         "darkbfs-gather",
         (
             bfs::gather,
             darkbfs::animate_gather,
-            darkbfs::animate_gather,
+            darkbfs::animate_mini_gather,
         ),
     ),
     (
@@ -297,19 +309,23 @@ pub const SOLVERS: [(&'static str, SolveFunction); 26] = [
         (
             bfs::corner,
             darkbfs::animate_corner,
-            darkbfs::animate_corner,
+            darkbfs::animate_mini_corner,
         ),
     ),
     (
         "floodfs-hunt",
-        (floodfs::hunt, floodfs::animate_hunt, floodfs::animate_hunt),
+        (
+            floodfs::hunt,
+            floodfs::animate_hunt,
+            floodfs::animate_mini_hunt,
+        ),
     ),
     (
         "floodfs-gather",
         (
             floodfs::gather,
             floodfs::animate_gather,
-            floodfs::animate_gather,
+            floodfs::animate_mini_gather,
         ),
     ),
     (
@@ -317,7 +333,7 @@ pub const SOLVERS: [(&'static str, SolveFunction); 26] = [
         (
             floodfs::corner,
             floodfs::animate_corner,
-            floodfs::animate_corner,
+            floodfs::animate_mini_corner,
         ),
     ),
     (
@@ -325,7 +341,7 @@ pub const SOLVERS: [(&'static str, SolveFunction); 26] = [
         (
             floodfs::hunt,
             darkfloodfs::animate_hunt,
-            darkfloodfs::animate_hunt,
+            darkfloodfs::animate_mini_hunt,
         ),
     ),
     (
@@ -333,7 +349,7 @@ pub const SOLVERS: [(&'static str, SolveFunction); 26] = [
         (
             floodfs::gather,
             darkfloodfs::animate_gather,
-            darkfloodfs::animate_gather,
+            darkfloodfs::animate_mini_gather,
         ),
     ),
     (
@@ -341,7 +357,7 @@ pub const SOLVERS: [(&'static str, SolveFunction); 26] = [
         (
             floodfs::corner,
             darkfloodfs::animate_corner,
-            darkfloodfs::animate_corner,
+            darkfloodfs::animate_mini_corner,
         ),
     ),
     (

--- a/maze_progs/tables/src/lib.rs
+++ b/maze_progs/tables/src/lib.rs
@@ -21,9 +21,14 @@ pub use solvers::floodfs;
 pub use solvers::rdfs;
 pub use solvers::solve;
 
-pub type BuildFunction = (fn(&mut maze::Maze), fn(&mut maze::Maze, speed::Speed));
+pub type BuildFunction = (
+    fn(&mut maze::Maze),
+    fn(&mut maze::Maze, speed::Speed),
+    fn(&mut maze::Maze, speed::Speed),
+);
 pub type SolveFunction = (
     fn(solve::SolverMonitor),
+    fn(solve::SolverMonitor, speed::Speed),
     fn(solve::SolverMonitor, speed::Speed),
 );
 
@@ -64,11 +69,12 @@ impl MazeRunner {
             build: (
                 recursive_backtracker::generate_maze,
                 recursive_backtracker::animate_maze,
+                recursive_backtracker::animate_mini_maze,
             ),
             modify: None,
             solve_view: ViewingMode::StaticImage,
             solve_speed: speed::Speed::Speed4,
-            solve: (dfs::hunt, dfs::animate_hunt),
+            solve: (dfs::hunt, dfs::animate_hunt, dfs::animate_mini_hunt),
         }
     }
 }
@@ -104,11 +110,19 @@ pub const WALL_STYLES: [(&'static str, maze::MazeStyle); 8] = [
 ];
 
 pub const BUILDERS: [(&'static str, BuildFunction); 9] = [
-    ("arena", (arena::generate_maze, arena::animate_maze)),
+    (
+        "arena",
+        (
+            arena::generate_maze,
+            arena::animate_maze,
+            arena::animate_mini_maze,
+        ),
+    ),
     (
         "rdfs",
         (
             recursive_backtracker::generate_maze,
+            recursive_backtracker::animate_maze,
             recursive_backtracker::animate_mini_maze,
         ),
     ),
@@ -117,70 +131,235 @@ pub const BUILDERS: [(&'static str, BuildFunction); 9] = [
         (
             recursive_subdivision::generate_maze,
             recursive_subdivision::animate_maze,
+            recursive_subdivision::animate_mini_maze,
         ),
     ),
-    ("prim", (prim::generate_maze, prim::animate_maze)),
-    ("kruskal", (kruskal::generate_maze, kruskal::animate_maze)),
-    ("eller", (eller::generate_maze, eller::animate_maze)),
+    (
+        "prim",
+        (
+            prim::generate_maze,
+            prim::animate_maze,
+            prim::animate_mini_maze,
+        ),
+    ),
+    (
+        "kruskal",
+        (
+            kruskal::generate_maze,
+            kruskal::animate_maze,
+            kruskal::animate_mini_maze,
+        ),
+    ),
+    (
+        "eller",
+        (
+            eller::generate_maze,
+            eller::animate_maze,
+            eller::animate_mini_maze,
+        ),
+    ),
     (
         "wilson",
-        (wilson_carver::generate_maze, wilson_carver::animate_maze),
+        (
+            wilson_carver::generate_maze,
+            wilson_carver::animate_maze,
+            wilson_carver::animate_mini_maze,
+        ),
     ),
     (
         "wilson-walls",
-        (wilson_adder::generate_maze, wilson_adder::animate_maze),
+        (
+            wilson_adder::generate_maze,
+            wilson_adder::animate_maze,
+            wilson_adder::animate_mini_maze,
+        ),
     ),
-    ("grid", (grid::generate_maze, grid::animate_maze)),
+    (
+        "grid",
+        (
+            grid::generate_maze,
+            grid::animate_maze,
+            grid::animate_mini_maze,
+        ),
+    ),
 ];
 
 pub const MODIFICATIONS: [(&'static str, BuildFunction); 2] = [
-    ("cross", (modify::add_cross, modify::add_cross_animated)),
-    ("x", (modify::add_x, modify::add_x_animated)),
+    (
+        "cross",
+        (
+            modify::add_cross,
+            modify::add_cross_animated,
+            modify::add_mini_cross_animated,
+        ),
+    ),
+    (
+        "x",
+        (
+            modify::add_x,
+            modify::add_x_animated,
+            modify::add_mini_x_animated,
+        ),
+    ),
 ];
 
-pub const SOLVERS: [(&'static str, SolveFunction); 27] = [
-    ("dfs-hunt", (dfs::hunt, dfs::animate_hunt)),
-    ("minidfs-hunt", (dfs::hunt, dfs::animate_mini_hunt)),
-    ("dfs-gather", (dfs::gather, dfs::animate_gather)),
-    ("dfs-corner", (dfs::corner, dfs::animate_corner)),
-    ("darkdfs-hunt", (dfs::hunt, darkdfs::animate_hunt)),
-    ("darkdfs-gather", (dfs::gather, darkdfs::animate_gather)),
-    ("darkdfs-corner", (dfs::corner, darkdfs::animate_corner)),
-    ("rdfs-hunt", (rdfs::hunt, rdfs::animate_hunt)),
-    ("rdfs-gather", (rdfs::gather, rdfs::animate_gather)),
-    ("rdfs-corner", (rdfs::corner, rdfs::animate_corner)),
-    ("darkrdfs-hunt", (rdfs::hunt, darkrdfs::animate_hunt)),
-    ("darkrdfs-gather", (rdfs::gather, darkrdfs::animate_gather)),
-    ("darkrdfs-corner", (rdfs::corner, darkrdfs::animate_corner)),
-    ("bfs-hunt", (bfs::hunt, bfs::animate_hunt)),
-    ("bfs-gather", (bfs::gather, bfs::animate_gather)),
-    ("bfs-corner", (bfs::corner, bfs::animate_corner)),
-    ("darkbfs-hunt", (bfs::hunt, darkbfs::animate_hunt)),
-    ("darkbfs-gather", (bfs::gather, darkbfs::animate_gather)),
-    ("darkbfs-corner", (bfs::corner, darkbfs::animate_corner)),
-    ("floodfs-hunt", (floodfs::hunt, floodfs::animate_hunt)),
-    ("floodfs-gather", (floodfs::gather, floodfs::animate_gather)),
-    ("floodfs-corner", (floodfs::corner, floodfs::animate_corner)),
+pub const SOLVERS: [(&'static str, SolveFunction); 26] = [
+    (
+        "dfs-hunt",
+        (dfs::hunt, dfs::animate_hunt, dfs::animate_mini_hunt),
+    ),
+    (
+        "dfs-gather",
+        (dfs::gather, dfs::animate_gather, dfs::animate_gather),
+    ),
+    (
+        "dfs-corner",
+        (dfs::corner, dfs::animate_corner, dfs::animate_corner),
+    ),
+    (
+        "darkdfs-hunt",
+        (dfs::hunt, darkdfs::animate_hunt, darkdfs::animate_hunt),
+    ),
+    (
+        "darkdfs-gather",
+        (
+            dfs::gather,
+            darkdfs::animate_gather,
+            darkdfs::animate_gather,
+        ),
+    ),
+    (
+        "darkdfs-corner",
+        (
+            dfs::corner,
+            darkdfs::animate_corner,
+            darkdfs::animate_corner,
+        ),
+    ),
+    (
+        "rdfs-hunt",
+        (rdfs::hunt, rdfs::animate_hunt, rdfs::animate_hunt),
+    ),
+    (
+        "rdfs-gather",
+        (rdfs::gather, rdfs::animate_gather, rdfs::animate_gather),
+    ),
+    (
+        "rdfs-corner",
+        (rdfs::corner, rdfs::animate_corner, rdfs::animate_corner),
+    ),
+    (
+        "darkrdfs-hunt",
+        (rdfs::hunt, darkrdfs::animate_hunt, darkrdfs::animate_hunt),
+    ),
+    (
+        "darkrdfs-gather",
+        (
+            rdfs::gather,
+            darkrdfs::animate_gather,
+            darkrdfs::animate_gather,
+        ),
+    ),
+    (
+        "darkrdfs-corner",
+        (
+            rdfs::corner,
+            darkrdfs::animate_corner,
+            darkrdfs::animate_corner,
+        ),
+    ),
+    (
+        "bfs-hunt",
+        (bfs::hunt, bfs::animate_hunt, bfs::animate_hunt),
+    ),
+    (
+        "bfs-gather",
+        (bfs::gather, bfs::animate_gather, bfs::animate_gather),
+    ),
+    (
+        "bfs-corner",
+        (bfs::corner, bfs::animate_corner, bfs::animate_corner),
+    ),
+    (
+        "darkbfs-hunt",
+        (bfs::hunt, darkbfs::animate_hunt, darkbfs::animate_hunt),
+    ),
+    (
+        "darkbfs-gather",
+        (
+            bfs::gather,
+            darkbfs::animate_gather,
+            darkbfs::animate_gather,
+        ),
+    ),
+    (
+        "darkbfs-corner",
+        (
+            bfs::corner,
+            darkbfs::animate_corner,
+            darkbfs::animate_corner,
+        ),
+    ),
+    (
+        "floodfs-hunt",
+        (floodfs::hunt, floodfs::animate_hunt, floodfs::animate_hunt),
+    ),
+    (
+        "floodfs-gather",
+        (
+            floodfs::gather,
+            floodfs::animate_gather,
+            floodfs::animate_gather,
+        ),
+    ),
+    (
+        "floodfs-corner",
+        (
+            floodfs::corner,
+            floodfs::animate_corner,
+            floodfs::animate_corner,
+        ),
+    ),
     (
         "darkfloodfs-hunt",
-        (floodfs::hunt, darkfloodfs::animate_hunt),
+        (
+            floodfs::hunt,
+            darkfloodfs::animate_hunt,
+            darkfloodfs::animate_hunt,
+        ),
     ),
     (
         "darkfloodfs-gather",
-        (floodfs::gather, darkfloodfs::animate_gather),
+        (
+            floodfs::gather,
+            darkfloodfs::animate_gather,
+            darkfloodfs::animate_gather,
+        ),
     ),
     (
         "darkfloodfs-corner",
-        (floodfs::corner, darkfloodfs::animate_corner),
+        (
+            floodfs::corner,
+            darkfloodfs::animate_corner,
+            darkfloodfs::animate_corner,
+        ),
     ),
     (
         "distance",
         (
             distance::paint_distance_from_center,
             distance::animate_distance_from_center,
+            distance::animate_distance_from_center,
         ),
     ),
-    ("runs", (runs::paint_run_lengths, runs::animate_run_lengths)),
+    (
+        "runs",
+        (
+            runs::paint_run_lengths,
+            runs::animate_run_lengths,
+            runs::animate_run_lengths,
+        ),
+    ),
 ];
 
 pub const SPEEDS: [(&'static str, speed::Speed); 7] = [

--- a/maze_progs/tables/src/lib.rs
+++ b/maze_progs/tables/src/lib.rs
@@ -365,7 +365,7 @@ pub const SOLVERS: [(&'static str, SolveFunction); 26] = [
         (
             distance::paint_distance_from_center,
             distance::animate_distance_from_center,
-            distance::animate_distance_from_center,
+            distance::animate_mini_distance_from_center,
         ),
     ),
     (
@@ -373,7 +373,7 @@ pub const SOLVERS: [(&'static str, SolveFunction); 26] = [
         (
             runs::paint_run_lengths,
             runs::animate_run_lengths,
-            runs::animate_run_lengths,
+            runs::animate_mini_run_lengths,
         ),
     ),
 ];

--- a/maze_progs/tables/src/lib.rs
+++ b/maze_progs/tables/src/lib.rs
@@ -138,8 +138,9 @@ pub const MODIFICATIONS: [(&'static str, BuildFunction); 2] = [
     ("x", (modify::add_x, modify::add_x_animated)),
 ];
 
-pub const SOLVERS: [(&'static str, SolveFunction); 26] = [
+pub const SOLVERS: [(&'static str, SolveFunction); 27] = [
     ("dfs-hunt", (dfs::hunt, dfs::animate_hunt)),
+    ("minidfs-hunt", (dfs::hunt, dfs::animate_mini_hunt)),
     ("dfs-gather", (dfs::gather, dfs::animate_gather)),
     ("dfs-corner", (dfs::corner, dfs::animate_corner)),
     ("darkdfs-hunt", (dfs::hunt, darkdfs::animate_hunt)),

--- a/maze_progs/tables/src/lib.rs
+++ b/maze_progs/tables/src/lib.rs
@@ -107,7 +107,7 @@ pub const BUILDERS: [(&'static str, BuildFunction); 9] = [
         "rdfs",
         (
             recursive_backtracker::generate_maze,
-            recursive_backtracker::animate_maze,
+            recursive_backtracker::animate_mini_maze,
         ),
     ),
     (


### PR DESCRIPTION
Mini mode is complete! This was a significant refactor and code edit. Mini mode means we use half sized Unicode blocks to represent our walls and paths. This has the visual appeal of making mazes more square and geometrically pleasing at the slight loss of ability to convey detailed maze information. This idea was given to me by the joshka from ratatui.rs. The downside is that it was very difficult to implement. Visually we need to convey the information of both path and wall in one Cursor tile. Because a Cursor is roughly twice as tall as it is wide, we can split the cursor vertically to convey information. Because I use many colors for both builders and solvers, I had to convey these colors by choosing which half of the cursor tile to make a background color and which to make a foreground color or an uncolored block. We then set the foreground half block color or the background empty space color to achieve the look. We are either conveying multiple colors of two path squares or a path and a wall or many other combinations of color and meaning. Dark mode also completely inverts all of this requiring brand new repetitive code. 

Similar to how we used a lookup table and bit encodings for the Unicode box drawing character walls we can do the same to some extent for half block walls. Here are the full set we work with.

```txt
'▀', '▄', '█'
```

We configure and color these in various combinations to convey meaning in our maze. I don't think I use the ' ' space character. While there is some encoding for lookups we can do, unfortunately the logic for this is extremely case dependent as I have it now. If you ever think of a more sane scheme, refactor this. I was able to achieve pretty much exactly the look I wanted so that is good. It just came at the cost of code complexity and bad practices. Hopefully users like it.