### PR TITLE
Mini modify

### DIFF
--- a/maze_progs/maze/src/lib.rs
+++ b/maze_progs/maze/src/lib.rs
@@ -203,7 +203,7 @@ pub static WALL_STYLES: [char; 128] = [
     // 0bWestSouthEastNorth. Note: 0b0000 is a floating wall with no walls around.
     // Then, count from 0 (0b0000) to 15 (0b1111) in binary to form different wall shapes.
     // mini
-    '▔', '▀', '▀', '▀', '█', '█', '█', '█', '▀', '▀', '▀', '▀', '█', '█', '█', '█',
+    '▀', '▀', '▀', '▀', '█', '█', '█', '█', '▀', '▀', '▀', '▀', '█', '█', '█', '█',
     // sharp
     '■', '╵', '╶', '└', '╷', '│', '┌', '├', '╴', '┘', '─', '┴', '┐', '┤', '┬', '┼',
     // rounded

--- a/maze_progs/painters/src/distance.rs
+++ b/maze_progs/painters/src/distance.rs
@@ -348,6 +348,7 @@ fn painter_mini_animated(
                         } else {
                             rgb::animate_mini_rgb(Some(channels), None, cur, lk.maze.offset());
                         }
+                    // This is an odd row.
                     } else if (lk.maze[(cur.row - 1) as usize][cur.col as usize] & maze::PATH_BIT)
                         != 0
                     {

--- a/maze_progs/run_maze/src/main.rs
+++ b/maze_progs/run_maze/src/main.rs
@@ -4,19 +4,7 @@ use solvers::solve;
 use std::env;
 
 fn main() {
-    // RAII approach to cursor hiding. Call hide and on scope drop it unhides, no call needed.
-    let invisible = print::InvisibleCursor::new();
-    invisible.hide();
-    ctrlc::set_handler(move || {
-        //print::clear_screen();
-        print::set_cursor_position(maze::Point { row: 50, col: 111 }, maze::Offset::default());
-        print::unhide_cursor_on_process_exit();
-        std::process::exit(0);
-    })
-    .expect("Could not set quit handler.");
-
     let mut run = tables::MazeRunner::new();
-
     let mut prev_flag: &str = "";
     let mut process_current = false;
     for a in env::args().skip(1) {
@@ -63,6 +51,22 @@ fn main() {
             arg: "[NONE]",
         }));
     }
+    // RAII approach to cursor hiding. Call hide and on scope drop it unhides, no call needed.
+    let invisible = print::InvisibleCursor::new();
+    invisible.hide();
+    ctrlc::set_handler(move || {
+        //print::clear_screen();
+        print::set_cursor_position(
+            maze::Point {
+                row: run.args.odd_rows + 3,
+                col: 0,
+            },
+            maze::Offset::default(),
+        );
+        print::unhide_cursor_on_process_exit();
+        std::process::exit(0);
+    })
+    .expect("Could not set quit handler.");
     if run.args.style == maze::MazeStyle::Mini {
         run.args.odd_rows *= 2;
     }

--- a/maze_progs/solvers/src/solve.rs
+++ b/maze_progs/solvers/src/solve.rs
@@ -378,11 +378,11 @@ pub fn flush_mini_path_coordinate(maze: &maze::Maze, point: maze::Point) {
         .expect("printer broke.");
         return;
     }
-    // A wall is above us
+    // A wall is below us
     execute!(
         io::stdout(),
         SetBackgroundColor(Color::AnsiValue(this_color)),
-        Print('▀'),
+        Print('▄'),
         ResetColor
     )
     .expect("printer broke.");
@@ -482,11 +482,11 @@ pub fn print_mini_point(maze: &maze::Maze, point: maze::Point) {
         .expect("printer broke.");
         return;
     }
-    // A wall is above us.
+    // A wall is below
     queue!(
         io::stdout(),
         SetBackgroundColor(Color::AnsiValue(this_color)),
-        Print('▀'),
+        Print('▄'),
         ResetColor
     )
     .expect("printer broke.");


### PR DESCRIPTION
This branch tracked down bugs in the mini mode modifiers. There were gaps being left in the maze when a modification occurred due to the ability of modifiers to alter even and odd squares. They do not build two squares at a time like the standard builders do. This creates a problem if we try to render a modified odd square with a half block that was previously rendered with a full block. Half the block is missing. This happened because I made some assumptions about what squares we would have to render and how in mini mode to cut down on lines of code because mini-mode is already a ton of complexity. However, by adding the code back in we get correctness with some slight overhead of longer functions. I prefer correctness first and maybe can find better strategies to cut code later.