### PR TITLE
Dep updates

### DIFF
--- a/maze_progs/Cargo.lock
+++ b/maze_progs/Cargo.lock
@@ -3,6 +3,24 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16,9 +34,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
 name = "builders"
@@ -85,7 +103,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "crossterm_winapi",
  "libc",
  "mio",
@@ -106,9 +124,9 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.4.0"
+version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a011bbe2c35ce9c1f143b7af6f94f29a167beb4cd1d29e6740ce836f723120e"
+checksum = "82e95fbd621905b854affdc67943b043a0fbb6ed7385fd5a25650d19a8a6cfdf"
 dependencies = [
  "nix",
  "windows-sys",
@@ -148,6 +166,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,15 +206,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
 name = "lock_api"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -194,9 +222,18 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
+name = "lru"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efa59af2ddfad1854ae27d75009d538d0998b4b2fd47083e743ac1a10e46c60"
+dependencies = [
+ "hashbrown",
+]
 
 [[package]]
 name = "maze"
@@ -207,9 +244,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
 dependencies = [
  "libc",
  "log",
@@ -219,15 +256,20 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.26.2"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.1",
  "cfg-if",
  "libc",
- "static_assertions",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "painters"
@@ -254,9 +296,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if",
  "libc",
@@ -335,15 +377,16 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e2e4cd95294a85c3b4446e63ef054eea43e0205b1fd60120c16b74ff7ff96ad"
+checksum = "0ebc917cfb527a566c37ecb94c7e3fd098353516fb4eb6bea17015ade0182425"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "cassowary",
  "crossterm 0.27.0",
  "indoc",
  "itertools",
+ "lru",
  "paste",
  "strum",
  "unicode-segmentation",
@@ -352,9 +395,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.3.5"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
 ]
@@ -401,9 +444,9 @@ checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "signal-hook"
@@ -437,9 +480,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "solvers"
@@ -459,12 +502,6 @@ name = "speed"
 version = "0.1.0"
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "strum"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,9 +512,9 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.25.2"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad8d03b598d3d0fff69bf533ee3ef19b8eeb342729596df84bcc7e1f96ec4059"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -510,12 +547,13 @@ dependencies = [
 
 [[package]]
 name = "tui-textarea"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddd5d2aea3541baccf9c298ecace702201e0fbf348e80bd8811acb4f62b5952"
+checksum = "a8aa3edc9087c29f51e753c6eebb7740e3140a519feb08f89443e5fd16a69b91"
 dependencies = [
  "crossterm 0.27.0",
  "ratatui",
+ "unicode-width",
 ]
 
 [[package]]
@@ -535,6 +573,12 @@ name = "unicode-width"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"
@@ -575,9 +619,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -590,42 +634,62 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81ba595b9f2772fbee2312de30eeb80ec773b4cb2f1e8098db024afadda6c06f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "772666c41fb6dceaf520b564b962d738a8e1a83b41bd48945f50837aed78bb1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/maze_progs/Cargo.toml
+++ b/maze_progs/Cargo.toml
@@ -12,3 +12,4 @@ members = [
     "print",
     "speed",
 ]
+resolver = "2"

--- a/maze_progs/builders/src/build.rs
+++ b/maze_progs/builders/src/build.rs
@@ -1122,6 +1122,7 @@ pub fn print_mini_coordinate(maze: &maze::Maze, p: maze::Point) {
     let square = maze[p.row as usize][p.col as usize];
     if square & maze::PATH_BIT == 0 {
         if p.row % 2 != 0 {
+            // By defenition of 0 indexing row - 1 is safe now.
             queue!(
                 io::stdout(),
                 Print(maze.wall_char(
@@ -1140,7 +1141,6 @@ pub fn print_mini_coordinate(maze: &maze::Maze, p: maze::Point) {
         .expect("Could not print.");
         return;
     }
-    // We are now in an even or odd row path.
     if p.row % 2 == 0 {
         queue!(
             io::stdout(),

--- a/maze_progs/painters/src/runs.rs
+++ b/maze_progs/painters/src/runs.rs
@@ -1,5 +1,5 @@
 use crate::rgb;
-use builders::build::print_square;
+use builders::build::{self, print_square};
 use maze;
 use solvers::solve;
 use speed;
@@ -251,35 +251,56 @@ fn painter(maze: &maze::Maze, map: &solve::MaxMap) {
         for r in 0..maze.row_size() {
             for c in 0..maze.col_size() {
                 let cur = maze::Point { row: r, col: c };
-                if (maze[r as usize][c as usize] & maze::PATH_BIT) == 0 {
-                    solve::print_mini_point(maze, cur);
-                    continue;
-                }
-                let dist = map.distances.get(&cur).expect("Could not find map entry?");
-                let intensity = (map.max - dist) as f64 / map.max as f64;
-                let dark = (255f64 * intensity) as u8;
-                let bright = 128 + (127f64 * intensity) as u8;
-                let mut channels: rgb::Rgb = [dark, dark, dark];
-                channels[rand_color_choice] = bright;
-                if (maze[(cur.row + 1) as usize][cur.col as usize] & maze::PATH_BIT) != 0 {
-                    let neighbor = maze::Point {
-                        row: cur.row + 1,
-                        col: cur.col,
-                    };
-                    let neighbor_dist = map.distances.get(&neighbor).expect("Empty map");
-                    let intensity = (map.max - neighbor_dist) as f64 / map.max as f64;
+                if let Some(run) = map.distances.get(&cur) {
+                    let intensity = (map.max - run) as f64 / map.max as f64;
                     let dark = (255f64 * intensity) as u8;
                     let bright = 128 + (127f64 * intensity) as u8;
-                    let mut neighbor_channels: rgb::Rgb = [dark, dark, dark];
-                    neighbor_channels[rand_color_choice] = bright;
-                    rgb::print_mini_rgb(
-                        Some(channels),
-                        Some(neighbor_channels),
-                        cur,
-                        maze.offset(),
-                    );
+                    let mut channels: rgb::Rgb = [dark, dark, dark];
+                    channels[rand_color_choice] = bright;
+                    if cur.row % 2 == 0 {
+                        if (maze[(cur.row + 1) as usize][cur.col as usize] & maze::PATH_BIT) != 0 {
+                            let neighbor = maze::Point {
+                                row: cur.row + 1,
+                                col: cur.col,
+                            };
+                            let neighbor_dist = map.distances.get(&neighbor).expect("Empty map");
+                            let intensity = (map.max - neighbor_dist) as f64 / map.max as f64;
+                            let dark = (255f64 * intensity) as u8;
+                            let bright = 128 + (127f64 * intensity) as u8;
+                            let mut neighbor_channels: rgb::Rgb = [dark, dark, dark];
+                            neighbor_channels[rand_color_choice] = bright;
+                            rgb::animate_mini_rgb(
+                                Some(channels),
+                                Some(neighbor_channels),
+                                cur,
+                                maze.offset(),
+                            );
+                        } else {
+                            rgb::animate_mini_rgb(Some(channels), None, cur, maze.offset());
+                        }
+                    } else if (maze[(cur.row - 1) as usize][cur.col as usize] & maze::PATH_BIT) != 0
+                    {
+                        let neighbor = maze::Point {
+                            row: cur.row - 1,
+                            col: cur.col,
+                        };
+                        let neighbor_dist = map.distances.get(&neighbor).expect("Empty map");
+                        let intensity = (map.max - neighbor_dist) as f64 / map.max as f64;
+                        let dark = (255f64 * intensity) as u8;
+                        let bright = 128 + (127f64 * intensity) as u8;
+                        let mut neighbor_channels: rgb::Rgb = [dark, dark, dark];
+                        neighbor_channels[rand_color_choice] = bright;
+                        rgb::animate_mini_rgb(
+                            Some(neighbor_channels),
+                            Some(channels),
+                            cur,
+                            maze.offset(),
+                        );
+                    } else {
+                        rgb::animate_mini_rgb(None, Some(channels), cur, maze.offset());
+                    }
                 } else {
-                    rgb::print_mini_rgb(Some(channels), None, cur, maze.offset());
+                    build::print_mini_coordinate(maze, cur);
                 }
             }
         }
@@ -301,6 +322,7 @@ fn painter(maze: &maze::Maze, map: &solve::MaxMap) {
             }
         }
     }
+    print::flush();
 }
 
 fn painter_animated(

--- a/maze_progs/painters/src/runs.rs
+++ b/maze_progs/painters/src/runs.rs
@@ -1,5 +1,5 @@
 use crate::rgb;
-use builders::build::{self, print_square};
+use builders::build;
 use maze;
 use solvers::solve;
 use speed;
@@ -317,7 +317,7 @@ fn painter(maze: &maze::Maze, map: &solve::MaxMap) {
                         channels[rand_color_choice] = bright;
                         rgb::print_rgb(channels, cur, maze.offset());
                     }
-                    None => print_square(maze, cur),
+                    None => build::print_square(maze, cur),
                 }
             }
         }

--- a/maze_progs/run_tui/Cargo.toml
+++ b/maze_progs/run_tui/Cargo.toml
@@ -14,8 +14,8 @@ tables = { path = "../tables" }
 print = { path = "../print" }
 speed = { path = "../speed" }
 crossterm = "0.27"
-ratatui = "0.23"
-tui-textarea = { version = "*", features = ["ratatui-crossterm"], default-features = false }
+ratatui = "0.24"
+tui-textarea = "0.3"
 rand = "0.8.5"
 ctrlc = "3.4.0"
 crossbeam-channel = "0.5"

--- a/maze_progs/run_tui/src/tui.rs
+++ b/maze_progs/run_tui/src/tui.rs
@@ -420,6 +420,7 @@ fn ui_info_prompt(f: &mut Frame<'_>) {
         .block(
             Block::default()
                 .borders(Borders::ALL)
+                .border_type(BorderType::Double)
                 .border_style(Style::new().fg(Color::Yellow))
                 .style(Style::default().bg(Color::Black)),
         )

--- a/maze_progs/run_tui/src/tui.rs
+++ b/maze_progs/run_tui/src/tui.rs
@@ -5,16 +5,14 @@ use crossterm::terminal::{EnterAlternateScreen, LeaveAlternateScreen};
 use rand::distributions::Bernoulli;
 use rand::prelude::Distribution;
 use rand::{seq::SliceRandom, thread_rng};
-use ratatui::prelude::Alignment;
-use ratatui::widgets::Clear;
-use ratatui::widgets::ScrollDirection;
-use ratatui::widgets::ScrollbarState;
-use ratatui::widgets::Wrap;
 use ratatui::{
     layout::{Constraint, Direction, Layout},
-    prelude::{Color, CrosstermBackend, Modifier},
+    prelude::{Alignment, Color, Frame, Modifier},
     style::Style,
-    widgets::{Block, Borders, Padding, Paragraph, Scrollbar, ScrollbarOrientation},
+    widgets::{
+        Block, BorderType, Borders, Clear, Padding, Paragraph, ScrollDirection, Scrollbar,
+        ScrollbarOrientation, ScrollbarState, Wrap,
+    },
 };
 use solvers::solve;
 use tui_textarea::{Input, Key, TextArea};
@@ -27,7 +25,6 @@ use std::{
 pub static PLACEHOLDER: &str = "Type Command or Press <ENTER> for Random";
 
 pub type CtEvent = crossterm::event::Event;
-pub type Frame<'a> = ratatui::Frame<'a, CrosstermBackend<std::io::Stderr>>;
 pub type CrosstermTerminal = ratatui::Terminal<ratatui::backend::CrosstermBackend<std::io::Stderr>>;
 pub type Err = Box<dyn std::error::Error>;
 pub type Result<T> = std::result::Result<T, Err>;
@@ -77,11 +74,11 @@ impl Scroller {
         match dir {
             ScrollDirection::Forward => {
                 self.pos = self.pos.saturating_add(2);
-                self.state = self.state.position(self.pos as u16);
+                self.state = self.state.position(self.pos);
             }
             ScrollDirection::Backward => {
                 self.pos = self.pos.saturating_sub(2);
-                self.state = self.state.position(self.pos as u16);
+                self.state = self.state.position(self.pos);
             }
         }
     }
@@ -197,6 +194,7 @@ impl Tui {
         cmd_prompt.set_placeholder_text(PLACEHOLDER);
         let text_block = Block::default()
             .borders(Borders::ALL)
+            .border_type(BorderType::Double)
             .border_style(Style::new().fg(Color::Yellow))
             .style(Style::default().bg(Color::Black));
         cmd_prompt.set_block(text_block);
@@ -360,6 +358,7 @@ fn ui_home(cmd: &mut TextArea, scroll: &mut Scroller, f: &mut Frame<'_>) {
         .block(
             Block::default()
                 .borders(Borders::ALL)
+                .border_type(BorderType::Double)
                 .border_style(Style::new().fg(Color::Yellow))
                 .style(Style::default().bg(Color::Black)),
         )
@@ -559,5 +558,5 @@ fn ui_err(msg: &str, f: &mut Frame<'_>) {
 }
 
 static INSTRUCTIONS: &str = include_str!("../../res/instructions.txt");
-static INSTRUCTIONS_LINE_COUNT: u16 = 70;
-static DESCRIPTION_LINE_COUNT: u16 = 50;
+static INSTRUCTIONS_LINE_COUNT: usize = 70;
+static DESCRIPTION_LINE_COUNT: usize = 50;

--- a/maze_progs/run_tui/src/tui.rs
+++ b/maze_progs/run_tui/src/tui.rs
@@ -453,6 +453,7 @@ fn ui_info(msg: &str, scroll: &mut Scroller, f: &mut Frame<'_>) {
         .block(
             Block::default()
                 .borders(Borders::ALL)
+                .border_type(BorderType::Double)
                 .border_style(Style::new().fg(Color::Yellow))
                 .style(Style::default().bg(Color::Black)),
         )


### PR DESCRIPTION
This update fixes the build and dependency issues for the project. I needed to upgrade ratatui to version 0.24 in order to prep for the render comparison branch but had to wait for tui-textarea to update their crate as well. Now that both are updated and compatible I can merge this branch and start a new branch that is focused on rendering the mazes instead of moving the cursor to print them. The new ratatui library gives me more low level tools to do this.