### PR TITLE
Stdout

### DIFF
--- a/maze_progs/run_tui/src/main.rs
+++ b/maze_progs/run_tui/src/main.rs
@@ -3,7 +3,7 @@ mod tui;
 use ratatui::prelude::{CrosstermBackend, Terminal};
 
 fn main() -> tui::Result<()> {
-    let backend = CrosstermBackend::new(std::io::stderr());
+    let backend = CrosstermBackend::new(std::io::stdout());
     let terminal = Terminal::new(backend)?;
     let events = tui::EventHandler::new(250);
     let mut tui = tui::Tui::new(terminal, events);

--- a/maze_progs/run_tui/src/tui.rs
+++ b/maze_progs/run_tui/src/tui.rs
@@ -99,7 +99,7 @@ impl Tui {
     /// It enables the raw mode and sets terminal properties.
     pub fn enter(&mut self) -> Result<()> {
         crossterm::terminal::enable_raw_mode()?;
-        crossterm::execute!(std::io::stderr(), EnterAlternateScreen, EnableMouseCapture)?;
+        crossterm::execute!(std::io::stdout(), EnterAlternateScreen, EnableMouseCapture)?;
 
         // Define a custom panic hook to reset the terminal properties.
         // This way, you won't have your terminal messed up if an unexpected error happens.
@@ -137,7 +137,7 @@ impl Tui {
     /// the terminal properties if unexpected errors occur.
     fn reset() -> Result<()> {
         crossterm::terminal::disable_raw_mode()?;
-        crossterm::execute!(std::io::stderr(), LeaveAlternateScreen, DisableMouseCapture)?;
+        crossterm::execute!(std::io::stdout(), LeaveAlternateScreen, DisableMouseCapture)?;
         Ok(())
     }
 

--- a/maze_progs/run_tui/src/tui.rs
+++ b/maze_progs/run_tui/src/tui.rs
@@ -25,7 +25,7 @@ use std::{
 pub static PLACEHOLDER: &str = "Type Command or Press <ENTER> for Random";
 
 pub type CtEvent = crossterm::event::Event;
-pub type CrosstermTerminal = ratatui::Terminal<ratatui::backend::CrosstermBackend<std::io::Stderr>>;
+pub type CrosstermTerminal = ratatui::Terminal<ratatui::backend::CrosstermBackend<std::io::Stdout>>;
 pub type Err = Box<dyn std::error::Error>;
 pub type Result<T> = std::result::Result<T, Err>;
 


### PR DESCRIPTION
Forgot to switch all ratatui related rendering to stdout. Stdout is much smoother across all platforms with finally some bearable performance on the WSL2 windows terminal option. And Mac and linux now cruise through any animation with ease.