### PR TITLE
Mac render fix

### DIFF
--- a/maze_progs/run_tui/src/tui.rs
+++ b/maze_progs/run_tui/src/tui.rs
@@ -519,8 +519,7 @@ impl EventHandler {
                             }
                             _ => {}
                         }
-                    }
-                    if last_delta.elapsed() >= deltas {
+                    } else if last_delta.elapsed() >= deltas {
                         sender.send(Pack::Render).expect("could not send.");
                         last_delta = Instant::now();
                     }


### PR DESCRIPTION
This branch fixes the errors in polling and reading that were present on MacOS when trying to send render and key events across threads. While I am not sure *exactly* why the issue occurs only on Mac, it seems to be a problem with `Duration::from_micros` timing. This is indeed a very short duration and the polling event thread seemed to starve itself from reading and sending key events when such a short duration was used. I changed all Durations to be a minimum of milliseconds, avoiding microseconds completely. This fixes the issue across linux and Mac and while I would like to have the potential of faster animations, the minimum render speed of 1ms seems plenty fast for now. Because this app is about seeing every detail of an algorithm a slightly slower top speed is acceptable.

I also improved the nesting in all render loops thanks to Rust's `while let...` paradigm that cleaned everything up nicely.