### PR TITLE
Fix Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you just want to get started follow these steps.
 
 ```zsh
 $ git clone https://github.com/agl-alexglopez/maze-tui.git
-$ cd maze_tui/maze_tui
+$ cd maze-tui/maze_tui
 $ cargo run --release --bin run_tui
 ```
 


### PR DESCRIPTION
The quick start commands assumed the repo would clone to maze_tui, but it clones to maze-tui