### PR TITLE
Clippy 1.85.0 fixes

### DIFF
--- a/maze_tui/builders/src/build.rs
+++ b/maze_tui/builders/src/build.rs
@@ -88,7 +88,7 @@ pub const GENERATE_DIRECTIONS: [maze::Point; 4] = [
 // Control the speed steps of animation in microseconds here.
 pub const BUILDER_SPEEDS: [SpeedUnit; 8] = [0, 5000, 2500, 1000, 500, 250, 100, 1];
 
-/// MAZE BOUNDS CHECKING AND HELPERS-------------------------------------------------------
+// MAZE BOUNDS CHECKING AND HELPERS-------------------------------------------------------
 
 pub fn reset_build(maze: &mut maze::Maze) {
     maze.as_slice_mut().fill(0b0)
@@ -159,9 +159,9 @@ fn get_mark(square: maze::Square) -> BacktrackSymbol {
     BACKTRACKING_SYMBOLS[(square & MARKERS_MASK) as usize]
 }
 
-/// WALL ADDER HELPERS-------------------------------------------------------------------
+// WALL ADDER HELPERS-------------------------------------------------------------------
 
-/// Data Driven functions no IO or animation concerns.
+// Data Driven functions no IO or animation concerns.
 
 pub fn build_wall_outline(maze: &mut maze::Maze) {
     for r in 0..maze.rows() {
@@ -215,12 +215,11 @@ pub fn carve_path_walls(maze: &mut maze::Maze, p: maze::Point) {
     }
 }
 
-/// PATH CARVING HELPERS-------------------------------------------------------------------
+// PATH CARVING HELPERS-------------------------------------------------------------------
 
 ///
 /// Data Driven with no IO or animation.
 ///
-
 pub fn fill_maze_with_walls(maze: &mut maze::Maze) {
     for r in 0..maze.rows() {
         for c in 0..maze.cols() {
@@ -349,7 +348,6 @@ pub fn build_wall_carefully(maze: &mut maze::Maze, p: maze::Point) {
 ///
 /// History tracking for playback and animation.
 ///
-
 pub fn fill_maze_history_with_walls(maze: &mut maze::Maze) {
     for r in 0..maze.rows() {
         for c in 0..maze.cols() {
@@ -789,11 +787,9 @@ pub fn build_path_history(maze: &mut maze::Maze, p: maze::Point) -> usize {
 /// and cursor movement capabilities. For the TUI that means choosing how to decode every possible
 /// maze square and display it as a ratatui.rs buffer Cell.
 ///
-
 ///
 /// TUI rendering helpers for decoding maze squares into Cells.
 ///
-
 pub fn decode_square(wall_row: &[char], square: maze::Square) -> Cell {
     if is_marked(square) {
         let mark = get_mark(square);

--- a/maze_tui/builders/src/eller.rs
+++ b/maze_tui/builders/src/eller.rs
@@ -29,7 +29,6 @@ struct IdMergeRequest {
 ///
 /// Data only maze generator
 ///
-
 pub fn generate_maze(monitor: monitor::MazeReceiver) {
     let mut lk = match monitor.solver.lock() {
         Ok(l) => l,
@@ -130,7 +129,6 @@ fn complete_final_row(maze: &mut maze::Maze, window: &mut SlidingSetWindow) {
 ///
 /// History based generator for animation and playback.
 ///
-
 pub fn generate_history(monitor: monitor::MazeMonitor) {
     let mut lk = match monitor.lock() {
         Ok(l) => l,
@@ -222,7 +220,6 @@ fn complete_final_row_history(maze: &mut maze::Maze, window: &mut SlidingSetWind
 ///
 /// Helper data structure implementation for managing sets available to all.
 ///
-
 impl SlidingSetWindow {
     fn new(maze: &maze::Maze) -> Self {
         let mut ids = vec![0; WINDOW_SIZE * maze.cols() as usize];

--- a/maze_tui/builders/src/grid.rs
+++ b/maze_tui/builders/src/grid.rs
@@ -13,7 +13,6 @@ struct RunStart {
 ///
 /// Data only maze generator
 ///
-
 pub fn generate_maze(monitor: monitor::MazeReceiver) {
     let mut lk = match monitor.solver.lock() {
         Ok(l) => l,
@@ -66,7 +65,6 @@ fn complete_run(maze: &mut maze::Maze, dfs: &mut Vec<maze::Point>, mut run: RunS
 ///
 /// History based generator for animation and playback.
 ///
-
 pub fn generate_history(monitor: monitor::MazeMonitor) {
     let mut lk = match monitor.lock() {
         Ok(l) => l,

--- a/maze_tui/builders/src/hunt_kill.rs
+++ b/maze_tui/builders/src/hunt_kill.rs
@@ -12,7 +12,6 @@ const GOING_WEST: DirectionMarker = build::FROM_WEST;
 ///
 /// Data only maze generator
 ///
-
 pub fn generate_maze(monitor: monitor::MazeReceiver) {
     let mut lk = match monitor.solver.lock() {
         Ok(l) => l,
@@ -74,7 +73,6 @@ pub fn generate_maze(monitor: monitor::MazeReceiver) {
 ///
 /// History based generator for animation and playback.
 ///
-
 pub fn generate_history(monitor: monitor::MazeMonitor) {
     let mut lk = match monitor.lock() {
         Ok(l) => l,

--- a/maze_tui/builders/src/kruskal.rs
+++ b/maze_tui/builders/src/kruskal.rs
@@ -9,7 +9,6 @@ use std::collections::HashMap;
 ///
 /// Data only maze generator
 ///
-
 pub fn generate_maze(monitor: monitor::MazeReceiver) {
     let mut lk = match monitor.solver.lock() {
         Ok(l) => l,
@@ -60,7 +59,6 @@ pub fn generate_maze(monitor: monitor::MazeReceiver) {
 ///
 /// History based generator for animation and playback.
 ///
-
 pub fn generate_history(monitor: monitor::MazeMonitor) {
     let mut lk = match monitor.lock() {
         Ok(l) => l,
@@ -111,7 +109,6 @@ pub fn generate_history(monitor: monitor::MazeMonitor) {
 ///
 /// Data only helpers available to all.
 ///
-
 fn load_shuffled_walls(maze: &maze::Maze) -> Vec<maze::Point> {
     let mut walls = Vec::new();
     for r in (1..maze.rows() - 1).step_by(2) {

--- a/maze_tui/builders/src/modify.rs
+++ b/maze_tui/builders/src/modify.rs
@@ -4,7 +4,6 @@ use maze;
 ///
 /// Data only maze generator
 ///
-
 pub fn add_cross(monitor: monitor::MazeReceiver) {
     let mut lk = match monitor.solver.lock() {
         Ok(l) => l,
@@ -136,7 +135,6 @@ fn add_negative_slope(maze: &mut maze::Maze, p: maze::Point) {
 ///
 /// History based generator for animation and playback.
 ///
-
 pub fn add_cross_history(monitor: monitor::MazeMonitor) {
     let mut lk = match monitor.lock() {
         Ok(l) => l,

--- a/maze_tui/builders/src/prim.rs
+++ b/maze_tui/builders/src/prim.rs
@@ -34,7 +34,6 @@ impl Ord for PriorityPoint {
 ///
 /// Data only maze generator
 ///
-
 pub fn generate_maze(monitor: monitor::MazeReceiver) {
     let mut lk = match monitor.solver.lock() {
         Ok(l) => l,
@@ -89,7 +88,6 @@ pub fn generate_maze(monitor: monitor::MazeReceiver) {
 ///
 /// History based generator for animation and playback.
 ///
-
 pub fn generate_history(monitor: monitor::MazeMonitor) {
     let mut lk = match monitor.lock() {
         Ok(l) => l,

--- a/maze_tui/builders/src/recursive_backtracker.rs
+++ b/maze_tui/builders/src/recursive_backtracker.rs
@@ -5,7 +5,6 @@ use rand::{seq::SliceRandom, thread_rng, Rng};
 ///
 /// Data only maze generator
 ///
-
 pub fn generate_maze(monitor: monitor::MazeReceiver) {
     let mut lk = match monitor.solver.lock() {
         Ok(l) => l,
@@ -55,7 +54,6 @@ pub fn generate_maze(monitor: monitor::MazeReceiver) {
 ///
 /// History based generator for animation and playback.
 ///
-
 pub fn generate_history(monitor: monitor::MazeMonitor) {
     let mut lk = match monitor.lock() {
         Ok(l) => l,

--- a/maze_tui/builders/src/recursive_subdivision.rs
+++ b/maze_tui/builders/src/recursive_subdivision.rs
@@ -18,7 +18,6 @@ const MIN_CHAMBER: i32 = 3;
 ///
 /// Data only maze generator
 ///
-
 pub fn generate_maze(monitor: monitor::MazeReceiver) {
     let mut lk = match monitor.solver.lock() {
         Ok(l) => l,
@@ -95,7 +94,6 @@ pub fn generate_maze(monitor: monitor::MazeReceiver) {
 ///
 /// History based generator for animation and playback.
 ///
-
 pub fn generate_history(monitor: monitor::MazeMonitor) {
     let mut lk = match monitor.lock() {
         Ok(l) => l,
@@ -172,7 +170,6 @@ pub fn generate_history(monitor: monitor::MazeMonitor) {
 ///
 /// Data only helpers.
 ///
-
 fn rand_even_div(rng: &mut ThreadRng, axis_limit: i32) -> i32 {
     2 * rng.gen_range(1..=((axis_limit - 2) / 2))
 }

--- a/maze_tui/builders/src/wilson_adder.rs
+++ b/maze_tui/builders/src/wilson_adder.rs
@@ -24,7 +24,6 @@ struct RandomWalk {
 ///
 /// Data only maze generator
 ///
-
 pub fn generate_maze(monitor: monitor::MazeReceiver) {
     let mut lk = match monitor.solver.lock() {
         Ok(l) => l,
@@ -152,7 +151,6 @@ fn build_with_marks(maze: &mut maze::Maze, cur: maze::Point, next: maze::Point) 
 ///
 /// History based generator for animation and playback.
 ///
-
 pub fn generate_history(monitor: monitor::MazeMonitor) {
     let mut lk = match monitor.lock() {
         Ok(l) => l,
@@ -428,7 +426,6 @@ fn bridge_gap_history(maze: &mut maze::Maze, cur: maze::Point, next: maze::Point
 ///
 /// Logic utilities available to all.
 ///
-
 fn is_valid_step(maze: &maze::Maze, next: maze::Point, prev: maze::Point) -> bool {
     next.row >= 0
         && next.row < maze.rows()

--- a/maze_tui/builders/src/wilson_carver.rs
+++ b/maze_tui/builders/src/wilson_carver.rs
@@ -23,7 +23,6 @@ struct RandomWalk {
 ///
 /// Data only maze generator
 ///
-
 pub fn generate_maze(monitor: monitor::MazeReceiver) {
     let mut lk = match monitor.solver.lock() {
         Ok(l) => l,
@@ -155,7 +154,6 @@ fn build_with_marks(maze: &mut maze::Maze, cur: maze::Point, next: maze::Point) 
 ///
 /// History based generator for animation and playback.
 ///
-
 pub fn generate_history(monitor: monitor::MazeMonitor) {
     let mut lk = match monitor.lock() {
         Ok(l) => l,
@@ -386,7 +384,6 @@ fn break_wall_history(maze: &mut maze::Maze, cur: maze::Point, next: maze::Point
 ///
 /// Data only helpers for all.
 ///
-
 fn is_valid_step(maze: &maze::Maze, next: maze::Point, prev: maze::Point) -> bool {
     next.row > 0
         && next.row < maze.rows() - 1

--- a/maze_tui/maze/src/lib.rs
+++ b/maze_tui/maze/src/lib.rs
@@ -302,7 +302,6 @@ impl Default for MazeArgs {
 /// history of deltas as a maze build and solve operation completes. We only need an index and
 /// we track deltas as simple before and after u32's and what square changed.
 ///
-
 impl Index<usize> for Tape {
     type Output = Delta;
     fn index(&self, index: usize) -> &Self::Output {
@@ -445,7 +444,6 @@ impl Tape {
 ///
 /// Free functions for when the maze object is not present but we still want static info.
 ///
-
 #[inline]
 pub fn wall_row(row_index: usize) -> &'static [char] {
     &WALL_STYLES[row_index * WALL_ROW..row_index * WALL_ROW + WALL_ROW]

--- a/maze_tui/painters/src/distance.rs
+++ b/maze_tui/painters/src/distance.rs
@@ -9,7 +9,6 @@ use rand::{thread_rng, Rng};
 ///
 /// Data only modifiers
 ///
-
 pub fn paint_distance_from_center(monitor: monitor::MazeReceiver) {
     let mut lk = match monitor.solver.lock() {
         Ok(l) => l,
@@ -70,7 +69,6 @@ fn painter(maze: &mut maze::Maze, map: &monitor::MaxMap) {
 ///
 /// History based solvers.
 ///
-
 pub fn paint_distance_from_center_history(monitor: monitor::MazeMonitor) {
     let start = if let Ok(mut lk) = monitor.lock() {
         let row_mid = lk.maze.rows() / 2;

--- a/maze_tui/painters/src/runs.rs
+++ b/maze_tui/painters/src/runs.rs
@@ -15,7 +15,6 @@ struct RunPoint {
 ///
 /// Data only measurements.
 ///
-
 pub fn paint_run_lengths(monitor: monitor::MazeReceiver) {
     let mut lk = match monitor.solver.lock() {
         Ok(l) => l,
@@ -89,7 +88,6 @@ fn painter(maze: &mut maze::Maze, map: &monitor::MaxMap) {
 ///
 /// History based solver.
 ///
-
 pub fn paint_run_lengths_history(monitor: monitor::MazeMonitor) {
     let start: maze::Point = if let Ok(mut lk) = monitor.lock() {
         let row_mid = lk.maze.rows() / 2;

--- a/maze_tui/run_tui/src/run.rs
+++ b/maze_tui/run_tui/src/run.rs
@@ -255,7 +255,7 @@ fn handle_reader(
 // A new tape runs to completion then resets the maze buffer to its starting state.
 fn new_tape(run: &tables::HistoryRunner) -> Playback {
     let monitor = monitor::Monitor::new(maze::Maze::new(run.args));
-    (run.build)(monitor.clone());
+    (run.build.function())(monitor.clone());
     if let Some(m) = run.modify {
         (m)(monitor.clone());
     }
@@ -282,7 +282,7 @@ fn new_tape(run: &tables::HistoryRunner) -> Playback {
 fn new_home_tape(rect: Rect) -> Playback {
     let run_bg = set_random_args(&rect);
     let bg_maze = monitor::Monitor::new(maze::Maze::new(run_bg.args));
-    (run_bg.build)(bg_maze.clone());
+    (run_bg.build.function())(bg_maze.clone());
     if let Some(m) = run_bg.modify {
         (m)(bg_maze.clone());
     }

--- a/maze_tui/run_tui/src/run.rs
+++ b/maze_tui/run_tui/src/run.rs
@@ -51,7 +51,6 @@ struct Playback {
 ///
 /// Main TUI program running and logic.
 ///
-
 /// The main render loop from the home page. This loop is relatively simple. When the more
 /// complex functionality of a maze animation is requested we will hand that off to another fn.
 pub fn run() -> tui::Result<()> {
@@ -253,7 +252,6 @@ fn handle_reader(
 /// until the maze generation and solving histories have been recorded. Then we decide how
 /// we want to play all of that back with the help of builder and solver decoding functions.
 ///
-
 // A new tape runs to completion then resets the maze buffer to its starting state.
 fn new_tape(run: &tables::HistoryRunner) -> Playback {
     let monitor = monitor::Monitor::new(maze::Maze::new(run.args));
@@ -310,7 +308,6 @@ fn new_home_tape(rect: Rect) -> Playback {
 ///
 /// Argument parsing from the tui-textarea or random generation if empty
 ///
-
 pub fn set_command_args(cmd: String, tui: &mut tui::Tui) -> Result<tables::HistoryRunner, String> {
     if cmd.is_empty() {
         return Ok(set_random_args(&tui.inner_maze_rect()[0]));
@@ -433,7 +430,6 @@ fn get_arg_section(flag: &str) -> &'static str {
 ///
 /// History function wrappers to help simplify what the runner is responsible for with playback.
 ///
-
 // A step just progresses the Tape based on whatever the current direction state is.
 impl Playback {
     fn build_step(&mut self) -> bool {

--- a/maze_tui/run_tui/src/tui.rs
+++ b/maze_tui/run_tui/src/tui.rs
@@ -107,7 +107,7 @@ pub struct SolveFrame<'a> {
     pub maze: &'a maze::Blueprint,
 }
 
-impl<'a> Tui<'a> {
+impl Tui<'_> {
     pub fn new(terminal: CrosstermTerminal, events: EventHandler) -> Self {
         let mut cmd_prompt = TextArea::default();
         cmd_prompt.set_cursor_line_style(Style::default());
@@ -533,8 +533,7 @@ impl EventHandler {
 ///
 /// Supporting implementations
 ///
-
-impl<'a> Widget for BuildFrame<'a> {
+impl Widget for BuildFrame<'_> {
     fn render(self, _area: Rect, buf: &mut Buffer) {
         if self.maze.is_mini() {
             let buf_area = buf.area;
@@ -569,7 +568,7 @@ impl<'a> Widget for BuildFrame<'a> {
     }
 }
 
-impl<'a> Widget for SolveFrame<'a> {
+impl Widget for SolveFrame<'_> {
     fn render(self, _area: Rect, buf: &mut Buffer) {
         if self.maze.is_mini() {
             let buf_area = buf.area;

--- a/maze_tui/solvers/src/bfs.rs
+++ b/maze_tui/solvers/src/bfs.rs
@@ -11,7 +11,6 @@ const BURST: usize = 4;
 ///
 /// Data only solvers------------------------------------------------------------------------------
 ///
-
 pub fn hunt(monitor: monitor::MazeReceiver) {
     let all_start: maze::Point = if let Ok(mut lk) = monitor.solver.lock() {
         let start = solve::pick_random_point(&lk.maze);
@@ -277,7 +276,6 @@ fn gatherer(monitor: monitor::MazeReceiver, guide: solve::ThreadGuide) {
 ///
 /// History based solvers for recording and playback-----------------------------------------------
 ///
-
 pub fn hunt_history(monitor: monitor::MazeMonitor) {
     let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
         let start = solve::pick_random_point(&lk.maze);

--- a/maze_tui/solvers/src/dfs.rs
+++ b/maze_tui/solvers/src/dfs.rs
@@ -8,7 +8,6 @@ use std::thread;
 ///
 /// Data only solvers------------------------------------------------------------------------------
 ///
-
 pub fn hunt(monitor: monitor::MazeReceiver) {
     let all_start: maze::Point = if let Ok(mut lk) = monitor.solver.lock() {
         let all_start = solve::pick_random_point(&lk.maze);
@@ -262,7 +261,6 @@ fn gatherer(monitor: monitor::MazeReceiver, guide: solve::ThreadGuide) {
 ///
 /// History based solvers for recording and playback-----------------------------------------------
 ///
-
 pub fn hunt_history(monitor: monitor::MazeMonitor) {
     let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
         let all_start = solve::pick_random_point(&lk.maze);

--- a/maze_tui/solvers/src/floodfs.rs
+++ b/maze_tui/solvers/src/floodfs.rs
@@ -8,7 +8,6 @@ use std::thread;
 ///
 /// Data only solvers------------------------------------------------------------------------------
 ///
-
 pub fn hunt(monitor: monitor::MazeReceiver) {
     let all_start: maze::Point = if let Ok(mut lk) = monitor.solver.lock() {
         let all_start = solve::pick_random_point(&lk.maze);
@@ -253,7 +252,6 @@ fn gatherer(monitor: monitor::MazeReceiver, guide: solve::ThreadGuide) {
 ///
 /// History based solvers for recording and playback-----------------------------------------------
 ///
-
 pub fn hunt_history(monitor: monitor::MazeMonitor) {
     let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
         let all_start = solve::pick_random_point(&lk.maze);

--- a/maze_tui/solvers/src/rdfs.rs
+++ b/maze_tui/solvers/src/rdfs.rs
@@ -8,7 +8,6 @@ use std::thread;
 ///
 /// Data only solvers------------------------------------------------------------------------------
 ///
-
 pub fn hunt(monitor: monitor::MazeReceiver) {
     let all_start: maze::Point = if let Ok(mut lk) = monitor.solver.lock() {
         let all_start = solve::pick_random_point(&lk.maze);
@@ -257,7 +256,6 @@ fn gatherer(monitor: monitor::MazeReceiver, guide: solve::ThreadGuide) {
 ///
 /// History based solvers for recording and playback-----------------------------------------------
 ///
-
 pub fn hunt_history(monitor: monitor::MazeMonitor) {
     let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
         let all_start = solve::pick_random_point(&lk.maze);

--- a/maze_tui/solvers/src/solve.rs
+++ b/maze_tui/solvers/src/solve.rs
@@ -46,7 +46,6 @@ pub const SOLVER_SPEEDS: [SolveSpeedUnit; 8] = [0, 20000, 10000, 5000, 2000, 100
 ///
 /// Logical helpers for bitwise operations.
 ///
-
 #[inline]
 pub fn is_start(square: maze::Square) -> bool {
     (square & START_BIT) != 0
@@ -95,7 +94,6 @@ fn is_valid_start_or_finish(maze: &maze::Maze, choice: maze::Point) -> bool {
 ///
 /// Setup functions for starting and finishing a solver section.
 ///
-
 pub fn reset_solve(maze: &mut maze::Maze) {
     for square in maze.as_slice_mut().iter_mut() {
         if (*square & maze::PATH_BIT) != 0 {
@@ -169,7 +167,6 @@ pub fn find_nearest_square(maze: &maze::Maze, choice: maze::Point) -> maze::Poin
 ///
 /// Playback and animation based logic for interacting with TUI buffer.
 ///
-
 pub fn decode_square(wall_row: &[char], square: maze::Square) -> Cell {
     // We have some special printing for the finish square. Not here.
     if is_finish(square) {

--- a/maze_tui/tables/src/lib.rs
+++ b/maze_tui/tables/src/lib.rs
@@ -103,7 +103,6 @@ pub const WALL_STYLES: [(&str, maze::MazeStyle); 8] = [
 ///
 /// History and playback specific tables
 ///
-
 pub const HISTORY_BUILDERS: [(&str, BuildHistoryFunction); 10] = [
     ("arena", arena::generate_history),
     ("rdfs", recursive_backtracker::generate_history),

--- a/maze_tui/tables/src/lib.rs
+++ b/maze_tui/tables/src/lib.rs
@@ -36,7 +36,7 @@ pub enum ViewingMode {
 #[derive(Clone, Copy)]
 pub struct HistoryRunner {
     pub args: maze::MazeArgs,
-    pub build: BuildHistoryFunction,
+    pub build: BuildHistoryType,
     pub modify: Option<BuildHistoryFunction>,
     pub solve: SolveHistoryFunction,
 }
@@ -50,7 +50,7 @@ impl HistoryRunner {
                 offset: maze::Offset::default(),
                 style: maze::MazeStyle::Sharp,
             },
-            build: recursive_backtracker::generate_history,
+            build: BuildHistoryType::RecursiveBacktracker(recursive_backtracker::generate_history),
             modify: None,
             solve: dfs::hunt_history,
         }
@@ -73,7 +73,7 @@ where
         .map(|(_, t)| t.clone())
 }
 
-pub fn load_info(cur_builder: &BuildHistoryFunction) -> &'static str {
+pub fn load_info(cur_builder: &BuildHistoryType) -> &'static str {
     match DESCRIPTIONS.iter().find(|(func, _)| func == cur_builder) {
         Some(&(_, desc)) => desc,
         None => "Coming Soon!",
@@ -100,20 +100,69 @@ pub const WALL_STYLES: [(&str, maze::MazeStyle); 8] = [
     ("spikes", maze::MazeStyle::Spikes),
 ];
 
+#[derive(Clone)]
+pub struct BuildHistoryEntry(pub BuildHistoryFunction);
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum BuildHistoryType {
+    Arena(BuildHistoryFunction),
+    RecursiveBacktracker(BuildHistoryFunction),
+    HuntKill(BuildHistoryFunction),
+    RecursiveSubdivision(BuildHistoryFunction),
+    Prim(BuildHistoryFunction),
+    Kruskal(BuildHistoryFunction),
+    Eller(BuildHistoryFunction),
+    WilsonCarver(BuildHistoryFunction),
+    WilsonAdder(BuildHistoryFunction),
+    Grid(BuildHistoryFunction),
+}
+impl BuildHistoryType {
+    pub fn function(&self) -> fn(std::sync::Arc<std::sync::Mutex<monitor::Monitor>>) {
+        match self {
+            BuildHistoryType::Arena(f) => *f,
+            BuildHistoryType::RecursiveBacktracker(f) => *f,
+            BuildHistoryType::HuntKill(f) => *f,
+            BuildHistoryType::RecursiveSubdivision(f) => *f,
+            BuildHistoryType::Prim(f) => *f,
+            BuildHistoryType::Kruskal(f) => *f,
+            BuildHistoryType::Eller(f) => *f,
+            BuildHistoryType::WilsonCarver(f) => *f,
+            BuildHistoryType::WilsonAdder(f) => *f,
+            BuildHistoryType::Grid(f) => *f,
+        }
+    }
+}
 ///
 /// History and playback specific tables
 ///
-pub const HISTORY_BUILDERS: [(&str, BuildHistoryFunction); 10] = [
-    ("arena", arena::generate_history),
-    ("rdfs", recursive_backtracker::generate_history),
-    ("hunt-kill", hunt_kill::generate_history),
-    ("fractal", recursive_subdivision::generate_history),
-    ("prim", prim::generate_history),
-    ("kruskal", kruskal::generate_history),
-    ("eller", eller::generate_history),
-    ("wilson", wilson_carver::generate_history),
-    ("wilson-walls", wilson_adder::generate_history),
-    ("grid", grid::generate_history),
+pub const HISTORY_BUILDERS: [(&str, BuildHistoryType); 10] = [
+    ("arena", BuildHistoryType::Arena(arena::generate_history)),
+    (
+        "rdfs",
+        BuildHistoryType::RecursiveBacktracker(recursive_backtracker::generate_history),
+    ),
+    (
+        "hunt-kill",
+        BuildHistoryType::HuntKill(hunt_kill::generate_history),
+    ),
+    (
+        "fractal",
+        BuildHistoryType::RecursiveSubdivision(recursive_subdivision::generate_history),
+    ),
+    ("prim", BuildHistoryType::Prim(prim::generate_history)),
+    (
+        "kruskal",
+        BuildHistoryType::Kruskal(kruskal::generate_history),
+    ),
+    ("eller", BuildHistoryType::Eller(eller::generate_history)),
+    (
+        "wilson",
+        BuildHistoryType::WilsonCarver(wilson_carver::generate_history),
+    ),
+    (
+        "wilson-walls",
+        BuildHistoryType::WilsonAdder(wilson_adder::generate_history),
+    ),
+    ("grid", BuildHistoryType::Grid(grid::generate_history)),
 ];
 
 pub const HISTORY_MODIFICATIONS: [(&str, BuildHistoryFunction); 2] = [
@@ -138,45 +187,45 @@ pub const HISTORY_SOLVERS: [(&str, SolveHistoryFunction); 14] = [
     ("runs", runs::paint_run_lengths_history),
 ];
 
-pub static DESCRIPTIONS: [(BuildHistoryFunction, &str); 10] = [
+pub static DESCRIPTIONS: [(BuildHistoryType, &str); 10] = [
     (
-        builders::arena::generate_history,
+        BuildHistoryType::Arena(builders::arena::generate_history),
         include_str!("../../res/arena.txt"),
     ),
     (
-        builders::eller::generate_history,
+        BuildHistoryType::Eller(builders::eller::generate_history),
         include_str!("../../res/eller.txt"),
     ),
     (
-        builders::grid::generate_history,
+        BuildHistoryType::Grid(builders::grid::generate_history),
         include_str!("../../res/grid.txt"),
     ),
     (
-        builders::hunt_kill::generate_history,
+        BuildHistoryType::HuntKill(builders::hunt_kill::generate_history),
         include_str!("../../res/hunt_kill.txt"),
     ),
     (
-        builders::kruskal::generate_history,
+        BuildHistoryType::Kruskal(builders::kruskal::generate_history),
         include_str!("../../res/kruskal.txt"),
     ),
     (
-        builders::prim::generate_history,
+        BuildHistoryType::Prim(builders::prim::generate_history),
         include_str!("../../res/prim.txt"),
     ),
     (
-        builders::recursive_backtracker::generate_history,
+        BuildHistoryType::RecursiveBacktracker(builders::recursive_backtracker::generate_history),
         include_str!("../../res/recursive_backtracker.txt"),
     ),
     (
-        builders::recursive_subdivision::generate_history,
+        BuildHistoryType::RecursiveSubdivision(builders::recursive_subdivision::generate_history),
         include_str!("../../res/recursive_subdivision.txt"),
     ),
     (
-        builders::wilson_adder::generate_history,
+        BuildHistoryType::WilsonAdder(builders::wilson_adder::generate_history),
         include_str!("../../res/wilson_adder.txt"),
     ),
     (
-        builders::wilson_carver::generate_history,
+        BuildHistoryType::WilsonCarver(builders::wilson_carver::generate_history),
         include_str!("../../res/wilson_carver.txt"),
     ),
 ];


### PR DESCRIPTION
![](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExNnl4M2xyY2g1YjJwaGU1bDY2OWp4a2Y1MmNsZ2V5Y3JubmdlNm05aCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/PgKc6XWRjJ4GgkAevA/giphy.gif)

Some clippy warnings about doc comments and function pointer comparison.
[Github issue](https://github.com/agl-alexglopez/maze-tui/issues/21)

Changes:
Added `BuildHistoryType` to avoid comparing function pointers.
Removed empty newlines.
Changed some doc comments to regular comments.

Outcome:
Zero clippy errors.
Continues to run.

Environment:
* Ubuntu 22.04 running in WSL on Windows 11
* clippy 0.1.85 (4d91de4e48 2025-02-17)
* cargo 1.85.0 (d73d2caf9 2024-12-31)
* rustc 1.85.0 (4d91de4e4 2025-02-17)
