### PR TITLE
builders use rgb and default to user terminal bg

### DIFF
--- a/maze_tui/run_tui/src/tui.rs
+++ b/maze_tui/run_tui/src/tui.rs
@@ -116,7 +116,7 @@ impl Tui<'_> {
             .borders(Borders::ALL)
             .border_type(BorderType::Double)
             .border_style(Style::new().fg(Color::Yellow))
-            .style(Style::default().bg(Color::Black));
+            .style(Style::default());
         cmd_prompt.set_block(text_block);
         cmd_prompt.set_alignment(Alignment::Center);
         Self {
@@ -213,7 +213,7 @@ impl Tui<'_> {
                         .borders(Borders::ALL)
                         .border_type(BorderType::Double)
                         .border_style(Style::new().fg(Color::Yellow))
-                        .style(Style::default().bg(Color::Black)),
+                        .style(Style::default()),
                 )
                 .alignment(Alignment::Left)
                 .scroll((self.scroll.pos as u16, 0));
@@ -286,7 +286,7 @@ impl Tui<'_> {
                         .borders(Borders::ALL)
                         .border_type(BorderType::Double)
                         .border_style(Style::new().fg(Color::Yellow))
-                        .style(Style::default().bg(Color::DarkGray)),
+                        .style(Style::default()),
                 )
                 .alignment(Alignment::Left)
                 .scroll((self.scroll.pos as u16, 0));
@@ -343,12 +343,7 @@ impl Tui<'_> {
                     Block::default()
                         .borders(Borders::ALL)
                         .border_style(Style::new().fg(Color::Red).bg(Color::Red))
-                        .style(
-                            Style::default()
-                                .bg(Color::Black)
-                                .fg(Color::Red)
-                                .add_modifier(Modifier::BOLD),
-                        ),
+                        .style(Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)),
                 )
                 .alignment(Alignment::Center);
             f.render_widget(Clear, err_layout_h);
@@ -396,7 +391,7 @@ impl Tui<'_> {
                         .borders(Borders::ALL)
                         .border_type(BorderType::Double)
                         .border_style(Style::new().fg(Color::Yellow))
-                        .style(Style::default().bg(Color::Black)),
+                        .style(Style::default()),
                 )
                 .wrap(Wrap { trim: true })
                 .scroll((scroll.pos as u16, 0));
@@ -449,22 +444,22 @@ impl Tui<'_> {
                     .borders(Borders::ALL)
                     .border_set(FORWARD_INDICICATOR)
                     .border_style(Style::new().fg(RED_PAUSE))
-                    .style(Style::default().bg(Color::Black)),
+                    .style(Style::default()),
                 (true, false) => Block::default()
                     .borders(Borders::ALL)
                     .border_set(REVERSE_INDICICATOR)
                     .border_style(Style::new().fg(RED_PAUSE))
-                    .style(Style::default().bg(Color::Black)),
+                    .style(Style::default()),
                 (false, true) => Block::default()
                     .borders(Borders::ALL)
                     .border_set(FORWARD_INDICICATOR)
                     .border_style(Style::new().fg(GREEN_FORWARD))
-                    .style(Style::default().bg(Color::Black)),
+                    .style(Style::default()),
                 (false, false) => Block::default()
                     .borders(Borders::ALL)
                     .border_set(REVERSE_INDICICATOR)
                     .border_style(Style::new().fg(BLUE_REVERSE))
-                    .style(Style::default().bg(Color::Black)),
+                    .style(Style::default()),
             })
             .alignment(Alignment::Center);
         self.terminal.draw(|f| {

--- a/maze_tui/solvers/src/solve.rs
+++ b/maze_tui/solvers/src/solve.rs
@@ -173,7 +173,10 @@ pub fn decode_square(wall_row: &[char], square: maze::Square) -> Cell {
         Cell {
             symbol: 'F'.to_string(),
             fg: RatColor::Indexed(ANSI_CYN),
-            bg: thread_rgb(square),
+            bg: match thread_rgb(square) {
+                RatColor::Rgb(0, 0, 0) => RatColor::Reset,
+                any => any,
+            },
             underline_color: RatColor::Reset,
             modifier: Modifier::BOLD | Modifier::SLOW_BLINK,
             skip: false,
@@ -182,7 +185,10 @@ pub fn decode_square(wall_row: &[char], square: maze::Square) -> Cell {
         Cell {
             symbol: 'S'.to_string(),
             fg: RatColor::Indexed(ANSI_CYN),
-            bg: RatColor::Reset,
+            bg: match thread_rgb(square) {
+                RatColor::Rgb(0, 0, 0) => RatColor::Reset,
+                any => any,
+            },
             underline_color: RatColor::Reset,
             modifier: Modifier::BOLD,
             skip: false,


### PR DESCRIPTION
The builders should use rgb colors to be consistent with the solvers. Also, prefer avoiding to set any explicit colors for text box backgrounds. User terminal emulator themes and shells can alter these colors greatly making the tui experience ugly. 

Defer to the user defaults in their terminal whenever possible so that `RatColor::Reset` will be the users normal terminal foreground and background. This makes the text boxes, maze lines, and overall appearance seem more tailored to each users terminal.

The one exception is mini walls. Mini walls are very complex to render right now and I have to force a background and foreground color choice.

Overall, these changes make the tui usable for both dark and light themed terminals. Though lighter colors will not appear as well in a white terminal, light terminals can still enjoy the animations decently well. 