### PR TITLE
Cut MazeReceiver

### DIFF
--- a/maze_tui/Cargo.lock
+++ b/maze_tui/Cargo.lock
@@ -64,22 +64,18 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.9"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c3242926edf34aec4ac3a77108ad4854bffaa2e4ddc1824124ce59231302d5"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
- "cfg-if",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.17"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d96137f14f244c37f989d9fff8f95e6c18b918e71f36638f8c49112e4c78f"
-dependencies = [
- "cfg-if",
-]
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
@@ -221,7 +217,6 @@ dependencies = [
 name = "monitor"
 version = "0.1.0"
 dependencies = [
- "crossbeam-channel",
  "maze",
 ]
 
@@ -432,7 +427,6 @@ name = "solvers"
 version = "0.1.0"
 dependencies = [
  "builders",
- "crossbeam-channel",
  "crossterm 0.26.1",
  "maze",
  "monitor",

--- a/maze_tui/builders/src/arena.rs
+++ b/maze_tui/builders/src/arena.rs
@@ -3,8 +3,8 @@ use maze;
 
 // Pure data driven algorithm with no display.
 
-pub fn generate_maze(monitor: monitor::MazeReceiver) {
-    let mut lk = match monitor.solver.lock() {
+pub fn generate_maze(monitor: monitor::MazeMonitor) {
+    let mut lk = match monitor.lock() {
         Ok(l) => l,
         Err(_) => print::maze_panic!("uncontested lock failure"),
     };

--- a/maze_tui/builders/src/eller.rs
+++ b/maze_tui/builders/src/eller.rs
@@ -29,8 +29,8 @@ struct IdMergeRequest {
 ///
 /// Data only maze generator
 ///
-pub fn generate_maze(monitor: monitor::MazeReceiver) {
-    let mut lk = match monitor.solver.lock() {
+pub fn generate_maze(monitor: monitor::MazeMonitor) {
+    let mut lk = match monitor.lock() {
         Ok(l) => l,
         Err(_) => print::maze_panic!("uncontested lock failure"),
     };

--- a/maze_tui/builders/src/grid.rs
+++ b/maze_tui/builders/src/grid.rs
@@ -13,8 +13,8 @@ struct RunStart {
 ///
 /// Data only maze generator
 ///
-pub fn generate_maze(monitor: monitor::MazeReceiver) {
-    let mut lk = match monitor.solver.lock() {
+pub fn generate_maze(monitor: monitor::MazeMonitor) {
+    let mut lk = match monitor.lock() {
         Ok(l) => l,
         Err(_) => print::maze_panic!("uncontested lock failure"),
     };

--- a/maze_tui/builders/src/hunt_kill.rs
+++ b/maze_tui/builders/src/hunt_kill.rs
@@ -12,8 +12,8 @@ const GOING_WEST: DirectionMarker = build::FROM_WEST;
 ///
 /// Data only maze generator
 ///
-pub fn generate_maze(monitor: monitor::MazeReceiver) {
-    let mut lk = match monitor.solver.lock() {
+pub fn generate_maze(monitor: monitor::MazeMonitor) {
+    let mut lk = match monitor.lock() {
         Ok(l) => l,
         Err(_) => print::maze_panic!("uncontested lock failure"),
     };

--- a/maze_tui/builders/src/kruskal.rs
+++ b/maze_tui/builders/src/kruskal.rs
@@ -9,8 +9,8 @@ use std::collections::HashMap;
 ///
 /// Data only maze generator
 ///
-pub fn generate_maze(monitor: monitor::MazeReceiver) {
-    let mut lk = match monitor.solver.lock() {
+pub fn generate_maze(monitor: monitor::MazeMonitor) {
+    let mut lk = match monitor.lock() {
         Ok(l) => l,
         Err(_) => print::maze_panic!("uncontested lock failure"),
     };

--- a/maze_tui/builders/src/modify.rs
+++ b/maze_tui/builders/src/modify.rs
@@ -4,8 +4,8 @@ use maze;
 ///
 /// Data only maze generator
 ///
-pub fn add_cross(monitor: monitor::MazeReceiver) {
-    let mut lk = match monitor.solver.lock() {
+pub fn add_cross(monitor: monitor::MazeMonitor) {
+    let mut lk = match monitor.lock() {
         Ok(l) => l,
         Err(_) => print::maze_panic!("uncontested lock failure"),
     };
@@ -23,8 +23,8 @@ pub fn add_cross(monitor: monitor::MazeReceiver) {
     }
 }
 
-pub fn add_x(monitor: monitor::MazeReceiver) {
-    let mut lk = match monitor.solver.lock() {
+pub fn add_x(monitor: monitor::MazeMonitor) {
+    let mut lk = match monitor.lock() {
         Ok(l) => l,
         Err(_) => print::maze_panic!("uncontested lock failure"),
     };

--- a/maze_tui/builders/src/prim.rs
+++ b/maze_tui/builders/src/prim.rs
@@ -34,8 +34,8 @@ impl Ord for PriorityPoint {
 ///
 /// Data only maze generator
 ///
-pub fn generate_maze(monitor: monitor::MazeReceiver) {
-    let mut lk = match monitor.solver.lock() {
+pub fn generate_maze(monitor: monitor::MazeMonitor) {
+    let mut lk = match monitor.lock() {
         Ok(l) => l,
         Err(_) => print::maze_panic!("uncontested lock failure"),
     };

--- a/maze_tui/builders/src/recursive_backtracker.rs
+++ b/maze_tui/builders/src/recursive_backtracker.rs
@@ -5,8 +5,8 @@ use rand::{seq::SliceRandom, thread_rng, Rng};
 ///
 /// Data only maze generator
 ///
-pub fn generate_maze(monitor: monitor::MazeReceiver) {
-    let mut lk = match monitor.solver.lock() {
+pub fn generate_maze(monitor: monitor::MazeMonitor) {
+    let mut lk = match monitor.lock() {
         Ok(l) => l,
         Err(_) => print::maze_panic!("uncontested lock failure"),
     };

--- a/maze_tui/builders/src/recursive_subdivision.rs
+++ b/maze_tui/builders/src/recursive_subdivision.rs
@@ -18,8 +18,8 @@ const MIN_CHAMBER: i32 = 3;
 ///
 /// Data only maze generator
 ///
-pub fn generate_maze(monitor: monitor::MazeReceiver) {
-    let mut lk = match monitor.solver.lock() {
+pub fn generate_maze(monitor: monitor::MazeMonitor) {
+    let mut lk = match monitor.lock() {
         Ok(l) => l,
         Err(_) => print::maze_panic!("uncontested lock failure"),
     };

--- a/maze_tui/builders/src/wilson_adder.rs
+++ b/maze_tui/builders/src/wilson_adder.rs
@@ -24,8 +24,8 @@ struct RandomWalk {
 ///
 /// Data only maze generator
 ///
-pub fn generate_maze(monitor: monitor::MazeReceiver) {
-    let mut lk = match monitor.solver.lock() {
+pub fn generate_maze(monitor: monitor::MazeMonitor) {
+    let mut lk = match monitor.lock() {
         Ok(l) => l,
         Err(_) => print::maze_panic!("uncontested lock failure"),
     };

--- a/maze_tui/builders/src/wilson_carver.rs
+++ b/maze_tui/builders/src/wilson_carver.rs
@@ -23,8 +23,8 @@ struct RandomWalk {
 ///
 /// Data only maze generator
 ///
-pub fn generate_maze(monitor: monitor::MazeReceiver) {
-    let mut lk = match monitor.solver.lock() {
+pub fn generate_maze(monitor: monitor::MazeMonitor) {
+    let mut lk = match monitor.lock() {
         Ok(l) => l,
         Err(_) => print::maze_panic!("uncontested lock failure"),
     };

--- a/maze_tui/monitor/Cargo.toml
+++ b/maze_tui/monitor/Cargo.toml
@@ -7,4 +7,3 @@ edition = "2021"
 
 [dependencies]
 maze = { path = "../maze" }
-crossbeam-channel = "0.5"

--- a/maze_tui/monitor/src/lib.rs
+++ b/maze_tui/monitor/src/lib.rs
@@ -1,4 +1,3 @@
-use crossbeam_channel::Receiver;
 use std::{
     collections::HashMap,
     sync::{Arc, Mutex},
@@ -40,22 +39,3 @@ impl Monitor {
 }
 
 pub type MazeMonitor = Arc<Mutex<Monitor>>;
-
-#[derive(Clone)]
-pub struct MazeReceiver {
-    pub solver: MazeMonitor,
-    pub quit_receiver: Receiver<bool>,
-}
-
-impl MazeReceiver {
-    pub fn new(m: maze::Maze, quit_rx: Receiver<bool>) -> Self {
-        Self {
-            solver: Monitor::new(m),
-            quit_receiver: quit_rx,
-        }
-    }
-
-    pub fn exit(&self) -> bool {
-        self.quit_receiver.is_full()
-    }
-}

--- a/maze_tui/painters/src/distance.rs
+++ b/maze_tui/painters/src/distance.rs
@@ -9,8 +9,8 @@ use rand::{thread_rng, Rng};
 ///
 /// Data only modifiers
 ///
-pub fn paint_distance_from_center(monitor: monitor::MazeReceiver) {
-    let mut lk = match monitor.solver.lock() {
+pub fn paint_distance_from_center(monitor: monitor::MazeMonitor) {
+    let mut lk = match monitor.lock() {
         Ok(l) => l,
         Err(_) => print::maze_panic!("Lock panic."),
     };

--- a/maze_tui/painters/src/runs.rs
+++ b/maze_tui/painters/src/runs.rs
@@ -15,8 +15,8 @@ struct RunPoint {
 ///
 /// Data only measurements.
 ///
-pub fn paint_run_lengths(monitor: monitor::MazeReceiver) {
-    let mut lk = match monitor.solver.lock() {
+pub fn paint_run_lengths(monitor: monitor::MazeMonitor) {
+    let mut lk = match monitor.lock() {
         Ok(l) => l,
         Err(_) => print::maze_panic!("Lock panic."),
     };

--- a/maze_tui/solvers/Cargo.toml
+++ b/maze_tui/solvers/Cargo.toml
@@ -11,6 +11,5 @@ monitor = { path = "../monitor" }
 builders = { path = "../builders" }
 print = { path = "../print" }
 crossterm = "0.26.1"
-crossbeam-channel = "0.5"
 rand = "0.8.5"
 ratatui = "0.24"

--- a/maze_tui/solvers/src/dfs.rs
+++ b/maze_tui/solvers/src/dfs.rs
@@ -8,8 +8,8 @@ use std::thread;
 ///
 /// Data only solvers------------------------------------------------------------------------------
 ///
-pub fn hunt(monitor: monitor::MazeReceiver) {
-    let all_start: maze::Point = if let Ok(mut lk) = monitor.solver.lock() {
+pub fn hunt(monitor: monitor::MazeMonitor) {
+    let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
         let all_start = solve::pick_random_point(&lk.maze);
         *lk.maze.get_mut(all_start.row, all_start.col) |= solve::START_BIT;
         let finish: maze::Point = solve::pick_random_point(&lk.maze);
@@ -50,8 +50,8 @@ pub fn hunt(monitor: monitor::MazeReceiver) {
     }
 }
 
-pub fn corner(monitor: monitor::MazeReceiver) {
-    let mut corner_starts: [maze::Point; 4] = if let Ok(mut lk) = monitor.solver.lock() {
+pub fn corner(monitor: monitor::MazeMonitor) {
+    let mut corner_starts: [maze::Point; 4] = if let Ok(mut lk) = monitor.lock() {
         let corner_starts = solve::set_corner_starts(&lk.maze);
         for p in corner_starts {
             *lk.maze.get_mut(p.row, p.col) |= solve::START_BIT;
@@ -109,12 +109,12 @@ pub fn corner(monitor: monitor::MazeReceiver) {
     }
 }
 
-fn hunter(monitor: monitor::MazeReceiver, guide: solve::ThreadGuide) {
+fn hunter(monitor: monitor::MazeMonitor, guide: solve::ThreadGuide) {
     let mut dfs: Vec<maze::Point> = Vec::with_capacity(solve::INITIAL_PATH_LEN);
     dfs.push(guide.start);
 
     'branching: while let Some(&cur) = dfs.last() {
-        if let Ok(mut lk) = monitor.solver.lock() {
+        if let Ok(mut lk) = monitor.lock() {
             if lk.win.is_some() {
                 for p in dfs {
                     *lk.maze.get_mut(p.row, p.col) |= guide.paint;
@@ -145,7 +145,7 @@ fn hunter(monitor: monitor::MazeReceiver, guide: solve::ThreadGuide) {
                 col: cur.col + p.col,
             };
 
-            if match monitor.solver.lock() {
+            if match monitor.lock() {
                 Ok(lk) => {
                     let square = lk.maze.get(next.row, next.col);
                     (square & guide.cache) == 0 && maze::is_path(square)
@@ -161,8 +161,8 @@ fn hunter(monitor: monitor::MazeReceiver, guide: solve::ThreadGuide) {
     }
 }
 
-pub fn gather(monitor: monitor::MazeReceiver) {
-    let all_start: maze::Point = if let Ok(mut lk) = monitor.solver.lock() {
+pub fn gather(monitor: monitor::MazeMonitor) {
+    let all_start: maze::Point = if let Ok(mut lk) = monitor.lock() {
         let all_start = solve::pick_random_point(&lk.maze);
         *lk.maze.get_mut(all_start.row, all_start.col) |= solve::START_BIT;
         for _ in 0..solve::NUM_GATHER_FINISHES {
@@ -205,11 +205,11 @@ pub fn gather(monitor: monitor::MazeReceiver) {
     }
 }
 
-fn gatherer(monitor: monitor::MazeReceiver, guide: solve::ThreadGuide) {
+fn gatherer(monitor: monitor::MazeMonitor, guide: solve::ThreadGuide) {
     let mut dfs: Vec<maze::Point> = Vec::with_capacity(solve::INITIAL_PATH_LEN);
     dfs.push(guide.start);
     'branching: while let Some(&cur) = dfs.last() {
-        if let Ok(mut lk) = monitor.solver.lock() {
+        if let Ok(mut lk) = monitor.lock() {
             match (
                 (lk.maze.get(cur.row, cur.col) & solve::FINISH_BIT) != 0,
                 (lk.maze.get(cur.row, cur.col) & solve::CACHE_MASK) == 0,
@@ -242,7 +242,7 @@ fn gatherer(monitor: monitor::MazeReceiver, guide: solve::ThreadGuide) {
                 row: cur.row + p.row,
                 col: cur.col + p.col,
             };
-            if match monitor.solver.lock() {
+            if match monitor.lock() {
                 Err(p) => print::maze_panic!("Solve thread panic: {}", p),
                 Ok(lk) => {
                     let square = lk.maze.get(next.row, next.col);


### PR DESCRIPTION
The `MazeReceiver` is no longer needed because the building and solving logic is allowed to run to completion without any concern for displaying to the screen. The builders and solvers simply operate over the in memory integers that represent the maze. The changes they make are recorded in the `Tape` type and are replayed later at our convenience. There is no longer a need to be able to communicate to a thread while it is running via a channel. 

The only channel we keep is the sender and receiver for our main render and key press loop with the user.