### PR TITLE
Event loop fix

### DIFF
--- a/maze_tui/run_tui/src/tui.rs
+++ b/maze_tui/run_tui/src/tui.rs
@@ -504,7 +504,7 @@ impl EventHandler {
                                             std::cmp::min(deltas.saturating_mul(2), MAX_DURATION);
                                     }
                                     _ => {
-                                        sender.send(Pack::Press(e)).expect("couldn't send press.");
+                                        sender.send(Pack::Press(e)).expect("send press error");
                                     }
                                 }
                             }
@@ -512,12 +512,12 @@ impl EventHandler {
                         CtEvent::Resize(_, _) => {
                             sender
                                 .send(Pack::Resize((), ()))
-                                .expect("could not send resize.");
+                                .expect("send resize error");
                         }
                         _ => {}
                     }
                 } else {
-                    sender.send(Pack::Render).expect("could not send delta.");
+                    sender.send(Pack::Render).expect("maze delta send error");
                     last_delta = Instant::now();
                 }
             }

--- a/maze_tui/run_tui/src/tui.rs
+++ b/maze_tui/run_tui/src/tui.rs
@@ -478,10 +478,9 @@ impl EventHandler {
         thread::spawn(move || {
             let mut last_delta = Instant::now();
             loop {
-                // If we poll at the min acceptable duration always then when the user speeds
-                // up or slows down the deltas for the maze rendering speed we still have a
-                // responsive UI not tied to rendering speed and we have a CPU utilization cap.
                 let elapsed = last_delta.elapsed();
+                // Using a timeout gives the CPU some time to park this thread with any remaining
+                // time we have until the next render while ensuring we don't miss keys.
                 let timeout = if deltas > elapsed {
                     deltas.saturating_sub(elapsed)
                 } else {


### PR DESCRIPTION
We can make the event loop do less busy waiting. Instead of polling at some fixed minimum we can poll the maximum of our maze delta time. This is not really a traditional render loop because we set up the maze to show exactly one step of the algorithm every time a render duration is up. 

We are not really rendering at a frame rate or using any physics style delta time concepts because the goal of this simulation requires the user can see and control exactly every step of every algorithm. Steps can't be skipped based on variable frame rates and delta time being sent to the maze building and solving algorithms. I might explore this further later but that would be a pretty intensive game dev style rendering for a simple maze generator in the terminal.